### PR TITLE
Skip Win+PY35 and add kmuehlbauer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
     number: 0
+    skip: True  # [win and py3]
 
 requirements:
     build:
@@ -84,3 +85,4 @@ about:
 extra:
   recipe-maintainers:
     - ocefpaf
+    - kmuehlbauer


### PR DESCRIPTION
I thought it would be OK to leave Win+PY35 failing, as a reminder that we should try again in a near future, but this is giving me some headaches in the IOOS channel.