### PR TITLE
Allow Python35 builds on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -49,7 +49,10 @@ set BLD_OPTS=%WIN64% ^
     TIFF_OPTS=-DBIGTIFF_SUPPORT ^
     PNG_EXTERNAL_LIB=1 ^
     PNGDIR=%LIBRARY_PREFIX% ^
-    PNG_LIB=%LIBRARY_LIB%\libpng.lib
+    PNG_LIB=%LIBRARY_LIB%\libpng.lib ^
+    PROJ_FLAGS=-DPROJ_STATIC ^
+    PROJ_INCLUDE="-I%LIBRARY_INC%" ^
+    PROJ_LIBRARY=%LIBRARY_LIB%\proj.lib
 
 nmake /f makefile.vc %BLD_OPTS%
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,8 +4,26 @@ if "%ARCH%"=="64" (
     set WIN64=
 )
 
+:: Work out MSVC_VER - needed for build process.
+:: Currently guess from Python version 
+if "%CONDA_PY%" == "27" (
+    set MSVC_VER=1500
+)
+if "%CONDA_PY%" == "34" (
+    set MSVC_VER=1600
+) 
+if "%CONDA_PY%" == "35" (
+    set MSVC_VER=1900
+) 
+
+IF "%MSVC_VER%"=="" (
+    echo "Python version not supported. Please update bld.bat"
+    exit 1
+)
+
 :: Need consistent flags between build and install.
 set BLD_OPTS=%WIN64% ^
+    MSVC_VER=%MSVC_VER% ^
     PYDIR=%PREFIX% ^
     GDAL_HOME=%LIBRARY_PREFIX% ^
     BINDIR=%LIBRARY_BIN% ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -52,7 +52,13 @@ set BLD_OPTS=%WIN64% ^
     PNG_LIB=%LIBRARY_LIB%\libpng.lib ^
     PROJ_FLAGS=-DPROJ_STATIC ^
     PROJ_INCLUDE="-I%LIBRARY_INC%" ^
-    PROJ_LIBRARY=%LIBRARY_LIB%\proj.lib
+    PROJ_LIBRARY=%LIBRARY_LIB%\proj.lib ^
+    OPENJPEG_ENABLED=YES ^
+    OPENJPEG_CFLAGS="-I%LIBRARY_INC%" ^
+    OPENJPEG_LIB=%LIBRARY_LIB%\openjp2.lib ^
+    OPENJPEG_VERSION=20100 ^
+    CURL_INC="-I%LIBRARY_INC%" ^
+    CURL_LIB="%LIBRARY_LIB%\libcurl.lib wsock32.lib wldap32.lib winmm.lib"
 
 nmake /f makefile.vc %BLD_OPTS%
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ source:
 
 build:
     number: 2
-    skip: True  # [win and py35]
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
         - setuptools
         - numpy x.x
         - hdf4  # [not win]
-        - hdf5
+        - hdf5 1.8.15.1
         - geos
         - proj.4
         - xerces-c
@@ -39,13 +39,13 @@ requirements:
         - zlib  # [not win]
         - jpeg  # [not win]
         - postgresql  # [linux]
-        - openjpeg  # [not win]
-        - curl  # [not win]
+        - openjpeg
+        - curl
     run:
         - python
         - numpy x.x
         - hdf4  # [not win]
-        - hdf5
+        - hdf5 1.8.15.1
         - geos
         - proj.4
         - xerces-c
@@ -57,8 +57,8 @@ requirements:
         - zlib  # [not win]
         - jpeg  # [not win]
         - postgresql  # [linux]
-        - openjpeg  # [not win]
-        - curl  # [not win]
+        - openjpeg
+        - curl
 
 test:
     files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,15 +80,14 @@ test:
         - osgeo._ogr
         - osgeo._osr
     commands:
-        - ogrinfo sites.shp  # [not win]
-        - ogrinfo.exe sites.shp  # [win]
-        - gdal_grid --version  # [not win]
-        - gdal_rasterize --version  # [not win]
-        - gdal_translate --version  # [not win]
-        - gdaladdo --version  # [not win]
-        - gdalenhance --version  # [not win]
-        - gdalwarp --version  # [not win]
-        - gdalinfo --formats  # [not win]
+        - ogrinfo sites.shp
+        - gdal_grid --version
+        - gdal_rasterize --version
+        - gdal_translate --version
+        - gdaladdo --version
+        - gdalenhance --version
+        - gdalwarp --version
+        - gdalinfo --formats
 
 about:
     home: http://www.gdal.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
         - install_scripts.patch
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win and py35]
     features:
         - vc9  # [win and py27]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,10 +1,52 @@
-import ogr
+from osgeo import gdal
+from osgeo import ogr
+from osgeo import osr
 
-cnt = ogr.GetDriverCount()
-for i in range(cnt):
-    print(ogr.GetDriver(i).GetName())
-
+# this module does some tests
 import os1_hw
+
+# Set GDAL_DATA. This is done normally done by the activate script,
+# but this doesn't happen in the testing environment
+import os
+if 'LIBRARY_PREFIX' in os.environ:
+    # Windows
+    gdalData = os.path.join(os.environ['LIBRARY_PREFIX'], 'share', 'gdal')
+else:
+    # Linux/OSX
+    gdalData = os.path.join(os.environ['PREFIX'], 'share', 'gdal')
+
+os.environ['GDAL_DATA'] = gdalData
+
+driver = gdal.GetDriverByName("netCDF")
+assert driver is not None
+
+# Commented out until HDF4 support for Windows available
+#driver = gdal.GetDriverByName("HDF4")
+#assert driver is not None
+
+driver = gdal.GetDriverByName("HDF5")
+assert driver is not None
+
+driver = gdal.GetDriverByName("GTiff")
+assert driver is not None
+
+driver = gdal.GetDriverByName("PNG")
+assert driver is not None
+
+driver = gdal.GetDriverByName("JPEG")
+assert driver is not None
+
+# only available when libkea successfully linked in
+driver = gdal.GetDriverByName("KEA")
+assert driver is not None
+
+# only available when xerces-c++ successfully linked in
+driver = ogr.GetDriverByName("GML")
+assert driver is not None
+
+# Commented out until openjpeg support for Windows available
+#driver = ogr.GetDriverByName("JP2OpenJPEG ")
+#assert driver is not None
 
 def has_geos():
     pnt1 = ogr.CreateGeometryFromWkt( 'POINT(10 20)' )
@@ -17,3 +59,21 @@ def has_geos():
     return hasgeos
 
 assert has_geos(), 'GEOS not available within GDAL'
+
+def has_proj():
+    sr1 = osr.SpatialReference()
+    sr1.ImportFromEPSG(4326) # lat long
+    sr2 = osr.SpatialReference()
+    sr2.ImportFromEPSG(28355) # GDA94 / MGA zone 55
+    osrex = osr.GetUseExceptions()
+    osr.UseExceptions()
+    hasproj = True
+    # use exceptions to determine if we have proj and epsg files
+    # otherwise we can't reliably determine if it has failed
+    try:
+        trans = osr.CoordinateTransformation(sr1, sr2)
+    except RuntimeError:
+        hasproj = False
+    return hasproj
+
+assert has_proj(), 'PROJ not available within GDAL'

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -44,9 +44,13 @@ assert driver is not None
 driver = ogr.GetDriverByName("GML")
 assert driver is not None
 
-# Commented out until openjpeg support for Windows available
-#driver = ogr.GetDriverByName("JP2OpenJPEG ")
-#assert driver is not None
+# only available when openjpeg successfully linked in 
+driver = gdal.GetDriverByName("JP2OpenJPEG")
+assert driver is not None
+
+# only available when curl successfully linked in 
+driver = gdal.GetDriverByName("WCS")
+assert driver is not None
 
 def has_geos():
     pnt1 = ogr.CreateGeometryFromWkt( 'POINT(10 20)' )


### PR DESCRIPTION
This pull request enables building GDAL with VC 2015 for Python 3.5. It also adds openjpeg and curl libraries, plus revamps the run_tests.py script.

I have fixed hdf5 to the 1.15.1 version until the problems with netcdf are resolved.