### PR TITLE
Re-render and add libzma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ env:
     - secure: "Y1f4ZD0cRx4goI3XXl5I8PZnTpvve1/zl8v/uK9EU0smIaphz6lPoUz/RCDOmbYLJcubxLqfW+EE7+dKli/37nAT6AeV9wi//LyUXdyenDUy2N3kT7jo3C/OQmqvG89O9d/8lG0FAiNZRNXMcIBcH3tZWkYKitgPuQD1S/Mky2EIVjGbQkTmRV9kIjq+zI2NMpg8GkToV28mCY+iy3dgU4SYXQDiygvHDUqBqyasyaIU1mQaBjMfKvTXAuC14ZDBSR6UyZ4LyrZE0tlh3DXfgE/0+x1qZJ+0m8yFjrTulDlYh5Jt5jwux2OaqWxuz1qt0qhaOr+stFrNVjPranykkceFXoVLeEewxyBzeSnai/EaDj9BKqwoAeQr5ak9A60u/qCTyOCE5ueeZgfMn2AktlW94oms1r7DxCN96KoWO7EC3b4JhNHEyhjtD+vodtoaQ9FnOOsjXfabO1N9NJIcYvTNBtlW+sCHNMGTHjzH8THASsrgYnnUByi7M/dNX//fpKdpx9+XfgGaI4vNoNHVrhA6gsN6YocHHcDdh5B7ikUEEMRpNO2V/3pAg2fL+RWUQTnAkWiWOHEoBFqQ3b2SNPykSZJ8U+8dv9MdPAdJRA8/wbXCHfstq4ODW//IF3SI9haqqgiknOTPj+mY9utuWQsRL27l36Q7ealT/zeKYd4="
 
 
-before install:
+before_install:
     - brew remove --force $(brew list)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,20 @@ environment:
       CONDA_NPY: 111
       CONDA_PY: 34
 
+    - TARGET_ARCH: x86
+      CONDA_NPY: 110
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_NPY: 110
+      CONDA_PY: 35
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 35
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 if [ $(uname) == Darwin ]; then
-    export LDFLAGS="-headerpad_max_install_names"
-    OPTS="--with-xml2=$PREFIX"
+  export LDFLAGS="-headerpad_max_install_names"
+  OPTS="--enable-rpath"
 else
-    OPTS="--with-pg=$PREFIX/bin/pg_config"
+  OPTS="--with-pg=$PREFIX/bin/pg_config --with-xml2=$PREFIX"
 fi
 
 CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib" \
@@ -26,7 +26,6 @@ CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib" \
             --with-libjson-c=$PREFIX \
             --with-expat=$PREFIX \
             --with-freexl=$PREFIX \
-            --with-liblzma=$PREFIX \
             --with-spatialite=$PREFIX \
             --enable-debug \
             $PGFLAG

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,8 @@ requirements:
         - giflib  # [not win]
         - json-c  # [not win]
         - freexl  # [not win]
-        - libxml2  # [not win]
-        - libspatialite  # [not win]
+        - xz  # [not win]
+        - libspatialite  # [linux]
     run:
         - python
         - numpy x.x
@@ -69,9 +69,8 @@ requirements:
         - giflib  # [not win]
         - json-c  # [not win]
         - freexl  # [not win]
-        - libxml2  # [not win]
-        - libspatialite  # [not win]
-
+        - xz  # [not win]
+        - libspatialite  # [linux]
 test:
     files:
         - os1_hw.py


### PR DESCRIPTION
I had problems compiling `libxml2` with `libzma` support, but after removing `libzma` from `libxml2` both `gdal` and `fiona` had issues with missing `libzma`. Let's try this approach for now, but I suspect my original problem was because `homebrew` was not properly removed (my bad [here](https://github.com/conda-forge/conda-smithy/pull/114/files#diff-4db594a93663b6584405af3d0607f2b6R30)). So I will re-visit this at a later time and maybe re-add `libzma` on `libxml2`. For now this seems to work and we need to get `gdal` and `fiona` out there.