### PR TITLE
Make gdal activate script also work in other shells.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
         - install_scripts.patch
 
 build:
-    number: 2
+    number: 3
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 if [[ -z "$GDAL_DATA" ]]; then
-  DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-  export GDAL_DATA="${DIR}/../../../share/gdal"
+  export GDAL_DATA=$(gdal-config --datadir)
   export _CONDA_SET_GDAL_DATA=1
 fi


### PR DESCRIPTION
See the related issue and PR at https://github.com/conda/conda-recipes/issues/677 and https://github.com/conda/conda-recipes/pull/679

I've tested this locally in bash and zsh.