### PR TITLE
Add support for Spatialite

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,9 @@ CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib" \
             --with-jpeg=$PREFIX \
             --with-libtiff=$PREFIX \
             --with-png=$PREFIX \
+	    --with-sqlite3=$PREFIX \
+            --with-spatialite=$PREFIX \
+	    --with-curl \
             --with-libz=$PREFIX \
             --disable-rpath \
             --without-pam \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
         - postgresql  # [not win]
         - openjpeg
         - curl
-        - sqlite
+        - sqlite  # [not win]
         - libspatialite  # [not win]
 
     run:
@@ -64,7 +64,7 @@ requirements:
         - postgresql  # [not win]
         - openjpeg
         - curl
-        - sqlite 
+        - sqlite  # [not win]
         - libspatialite  # [not win]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
         - install_scripts.patch
 
 build:
-    number: 3
+    number: 4
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -27,7 +27,7 @@ requirements:
     build:
         - python
         - setuptools
-        - numpy x.x
+        - numpy x.xx
         - hdf4
         - hdf5 1.8.15*
         - geos
@@ -43,9 +43,12 @@ requirements:
         - postgresql  # [linux]
         - openjpeg
         - curl
+        - sqlite
+        - libspatialite # [not win]
+
     run:
         - python
-        - numpy x.x
+        - numpy x.xx
         - hdf4
         - hdf5 1.8.15*
         - geos
@@ -58,9 +61,11 @@ requirements:
         - libpng 1.6*
         - zlib 1.2*  # [not win]
         - jpeg 9*
-        - postgresql  # [linux]
+        - postgresql  # [not win]
         - openjpeg
         - curl
+        - sqlite 
+        - libspatialite # [linux]
 
 test:
     files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     build:
         - python
         - setuptools
-        - numpy x.xx
+        - numpy x.x
         - hdf4
         - hdf5 1.8.15*
         - geos
@@ -40,15 +40,15 @@ requirements:
         - libpng 1.6*
         - zlib 1.2*  # [not win]
         - jpeg 9*
-        - postgresql  # [linux]
+        - postgresql  # [not win]
         - openjpeg
         - curl
         - sqlite
-        - libspatialite # [not win]
+        - libspatialite  # [not win]
 
     run:
         - python
-        - numpy x.xx
+        - numpy x.x
         - hdf4
         - hdf5 1.8.15*
         - geos
@@ -65,7 +65,7 @@ requirements:
         - openjpeg
         - curl
         - sqlite 
-        - libspatialite # [linux]
+        - libspatialite  # [not win]
 
 test:
     files:


### PR DESCRIPTION
The current changes add support for Spatilate (see #66). Tested
on Linux, and compilation and everything else works. Currently,
the Windows makefile hasn't been changed. The changes are quite
similar to the 1.x branch changes that already support spatialite.