### PR TITLE
use toolchain

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,6 @@
 source activate "${CONDA_DEFAULT_ENV}"
 
 if [ $(uname) == Darwin ]; then
-    export LDFLAGS="-headerpad_max_install_names"
     OPTS="--enable-rpath"
     export CXX="${CXX} -stdlib=libc++"
 else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
 if [ $(uname) == Darwin ]; then
     export LDFLAGS="-headerpad_max_install_names"
     OPTS="--enable-rpath"
+    export CXX="${CXX} -stdlib=libc++"
 else
     OPTS="--disable-rpath"
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -43,7 +43,8 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
             --with-sqlite3=$PREFIX \
             --with-curl \
             --with-python \
-            $OPTS
+            --without-libtool \
+            $OPTS $LIBT
 
 
 if [[ $(uname) == Darwin ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
         - install_scripts.patch
 
 build:
-    number: 5
+    number: 6
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -28,6 +28,7 @@ requirements:
     build:
         - python
         - setuptools
+        - toolchain
         - cmake  # [win]
         - numpy x.x
         - hdf4


### PR DESCRIPTION
This PR updates the GDAL build to use the toolchain which should fix linking errors on OSX.

ping @jakirkham 