### PR TITLE
remove symlinks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -44,7 +44,7 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
             --with-curl \
             --with-python \
             --without-libtool \
-            $OPTS $LIBT
+            $OPTS
 
 
 if [[ $(uname) == Darwin ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
         - install_scripts.patch
 
 build:
-    number: 7
+    number: 6
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
         - install_scripts.patch
 
 build:
-    number: 6
+    number: 7
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
I forgot to unpin `conda-build` when using `toolchain` which means symlinks get left in. This should fix it.

cc @jakirkham
