### PR TITLE
WIP: Add missing Windows packages and tests

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -64,7 +64,15 @@ set BLD_OPTS=%WIN64% ^
     OPENJPEG_LIB=%LIBRARY_LIB%\openjp2.lib ^
     OPENJPEG_VERSION=20100 ^
     CURL_INC="-I%LIBRARY_INC%" ^
-    CURL_LIB="%LIBRARY_LIB%\libcurl.lib wsock32.lib wldap32.lib winmm.lib"
+    CURL_LIB="%LIBRARY_LIB%\libcurl.lib wsock32.lib wldap32.lib winmm.lib" ^
+    FREEXL_CFLAGS="-I%LIBRARY_INC%" ^
+    FREEXL_LIBS=%LIBRARY_LIB%\freexl_i.lib ^
+    EXPAT_DIR=%LIBRARY_PREFIX% ^
+    EXPAT_INCLUDE="-I%LIBRARY_INC%" ^
+    EXPAT_LIB=%LIBRARY_LIB%\expat.lib ^
+    SQLITE_INC="-I%LIBRARY_INC% -DHAVE_SPATIALITE" ^
+    SQLITE_LIB="%LIBRARY_LIB%\sqlite3.lib %LIBRARY_LIB%\spatialite_i.lib" ^
+    SPATIALITE_412_OR_LATER=yes
 
 nmake /f makefile.vc %BLD_OPTS%
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
         - python
         - setuptools
         - toolchain
-        - cmake  # [win]
         - numpy x.x
         - hdf4
         - hdf5 1.8.17|1.8.17.*
@@ -38,7 +37,6 @@ requirements:
         - xerces-c
         - libnetcdf 4.4.*
         - kealib
-        - krb5
         - libtiff 4.0.*
         - libpng >=1.6.21,<1.7
         - zlib 1.2.*  # [not win]
@@ -63,7 +61,6 @@ requirements:
         - xerces-c
         - libnetcdf 4.4.*
         - kealib
-        - krb5
         - libtiff 4.0.*
         - libpng >=1.6.21,<1.7
         - zlib 1.2.*  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
         - install_scripts.patch
 
 build:
-    number: 6
+    number: 7
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -46,12 +46,12 @@ requirements:
         - postgresql  # [not win]
         - giflib  # [not win]
         - json-c  # [not win]
-        - freexl  # [not win]
+        - freexl
         - openjpeg
         - curl
         - expat
-        - sqlite  # [not win]
-        - libspatialite  # [not win]
+        - sqlite 3.13.*
+        - libspatialite
 
     run:
         - python
@@ -71,12 +71,12 @@ requirements:
         - postgresql  # [not win]
         - giflib  # [not win]
         - json-c  # [not win]
-        - freexl  # [not win]
+        - freexl
         - openjpeg
         - curl
         - expat
-        - sqlite  # [not win]
-        - libspatialite  # [not win]
+        - sqlite 3.13.*
+        - libspatialite
 
 test:
     files:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -51,6 +51,18 @@ assert driver is not None
 driver = gdal.GetDriverByName("WCS")
 assert driver is not None
 
+# only available when freexl successfully linked in
+driver = ogr.GetDriverByName("XLS")
+assert driver is not None
+
+# only available when expat successfully linked in
+driver = ogr.GetDriverByName("KML")
+assert driver is not None
+
+# only available when SQLite successfully linked in
+driver = ogr.GetDriverByName("SQLite")
+assert driver is not None
+
 def has_geos():
     pnt1 = ogr.CreateGeometryFromWkt( 'POINT(10 20)' )
     pnt2 = ogr.CreateGeometryFromWkt( 'POINT(30 20)' )


### PR DESCRIPTION
This closes #74 and #76. 

There aren't options to compile with external `zlib`, `giflib` or `json-c` on Windows. I've also skipped `postgresql` since we don't yet have Windows libs for it.

I'm not sure why this package depends on `krb5` - there doesn't seem to be an option to use it. Am I missing something?