### PR TITLE
WIP: FIX: give CC and CXX as configure parameters

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,7 +21,9 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
 # `--without-pam` was removed.
 # See https://github.com/conda-forge/gdal-feedstock/pull/47 for the discussion.
 
-./configure --prefix=$PREFIX \
+./configure CC=$CC \
+            CXX=$CXX \
+            --prefix=$PREFIX \
             --with-hdf4=$PREFIX \
             --with-hdf5=$PREFIX \
             --with-xerces=$PREFIX \
@@ -43,7 +45,6 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
             --with-sqlite3=$PREFIX \
             --with-curl \
             --with-python \
-            --without-libtool \
             $OPTS
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,11 +18,17 @@ fi
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
 
+# make copy and unset CC and CXX
+# see https://github.com/conda-forge/gdal-feedstock/issues/81
+export CF_CC=$CC
+export CF_CXX=$CXX
+unset CC CXX
+
 # `--without-pam` was removed.
 # See https://github.com/conda-forge/gdal-feedstock/pull/47 for the discussion.
 
-./configure CC=$CC \
-            CXX=$CXX \
+./configure CC=$CF_CC \
+            CXX=$CF_CXX \
             --prefix=$PREFIX \
             --with-hdf4=$PREFIX \
             --with-hdf5=$PREFIX \


### PR DESCRIPTION
This should fix the libtool-problem experienced in #79. Discussion went ahead in #81. 

Update:

This fixes some issue with configure and libtool. Obviously CC and CXX exported in the environment break the build. Therefore this PR copies CC and CXX unsets CC and CXX and feeds the copy to the configure script. 