### PR TITLE
WIP: DO NOT MERGE: demonstration of $CONFIG_SITE

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -64,7 +64,15 @@ set BLD_OPTS=%WIN64% ^
     OPENJPEG_LIB=%LIBRARY_LIB%\openjp2.lib ^
     OPENJPEG_VERSION=20100 ^
     CURL_INC="-I%LIBRARY_INC%" ^
-    CURL_LIB="%LIBRARY_LIB%\libcurl.lib wsock32.lib wldap32.lib winmm.lib"
+    CURL_LIB="%LIBRARY_LIB%\libcurl.lib wsock32.lib wldap32.lib winmm.lib" ^
+    FREEXL_CFLAGS="-I%LIBRARY_INC%" ^
+    FREEXL_LIBS=%LIBRARY_LIB%\freexl_i.lib ^
+    EXPAT_DIR=%LIBRARY_PREFIX% ^
+    EXPAT_INCLUDE="-I%LIBRARY_INC%" ^
+    EXPAT_LIB=%LIBRARY_LIB%\expat.lib ^
+    SQLITE_INC="-I%LIBRARY_INC% -DHAVE_SPATIALITE" ^
+    SQLITE_LIB="%LIBRARY_LIB%\sqlite3.lib %LIBRARY_LIB%\spatialite_i.lib" ^
+    SPATIALITE_412_OR_LATER=yes
 
 nmake /f makefile.vc %BLD_OPTS%
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,13 +10,12 @@ source activate "${CONDA_DEFAULT_ENV}"
 
 if [ $(uname) == Darwin ]; then
     OPTS="--enable-rpath"
-    export CXX="${CXX} -stdlib=libc++"
 else
     OPTS="--disable-rpath"
 fi
 
-export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
-export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
+# experimental CONFIG_SITE support
+export CONFIG_SITE=`pwd`/config.site
 
 # `--without-pam` was removed.
 # See https://github.com/conda-forge/gdal-feedstock/pull/47 for the discussion.
@@ -43,7 +42,6 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
             --with-sqlite3=$PREFIX \
             --with-curl \
             --with-python \
-            --without-libtool \
             $OPTS
 
 

--- a/recipe/config_site.patch
+++ b/recipe/config_site.patch
@@ -1,0 +1,51 @@
+--- /dev/null	2016-07-02 15:43:08.000000000 +1000
++++ config.site	2016-07-02 15:53:31.000000000 +1000
+@@ -0,0 +1,48 @@
++
++if [ "$(uname)" == "Darwin" ]
++then
++    # for Mac OSX
++    CC=clang
++    CXX=clang++
++    MACOSX_VERSION_MIN="10.9"
++    MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
++    CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
++    CFLAGS="${CFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
++    CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
++    CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
++    LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
++    LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
++    LDFLAGS="${LDFLAGS} -lc++"
++    LINKFLAGS="${LDFLAGS}"
++elif [ "$(uname)" == "Linux" ]
++then
++    # for Linux
++    CC=gcc
++    CXX=g++
++    CFLAGS="${CFLAGS}"
++    # Boost wants to enable `float128` support on Linux by default.
++    # However, we don't install `libquadmath` so it will fail to find
++    # the needed headers and fail to compile things. Adding this flag
++    # tells Boost not to support `float128` and avoids this search
++    # process. As it has confused a few people. We have added it here.
++    # The idea to add this flag was inspired by this Boost ticked.
++    #
++    # https://svn.boost.org/trac/boost/ticket/9240
++    #
++    CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
++    LDFLAGS="${LDFLAGS}"
++    LINKFLAGS="${LDFLAGS}"
++else
++    echo "This system is unsupported by the toolchain."
++    exit 1
++fi
++
++CFLAGS="${CFLAGS} -m${ARCH}"
++CXXFLAGS="${CXXFLAGS} -m${ARCH}"
++
++# not sure about this bit - needed for GDAL
++LDFLAGS="$LDFLAGS -L$PREFIX/lib"
++CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
++
++# make sure we always suceed as some things check
++true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     build:
         - python
         - setuptools
-        - cmake  # [win]
         - numpy x.x
         - hdf4
         - hdf5 1.8.17|1.8.17.*
@@ -38,7 +37,6 @@ requirements:
         - xerces-c
         - libnetcdf 4.4.*
         - kealib
-        - krb5
         - libtiff 4.0.*
         - libpng >=1.6.21,<1.7
         - zlib 1.2.*  # [not win]
@@ -46,12 +44,12 @@ requirements:
         - postgresql  # [not win]
         - giflib  # [not win]
         - json-c  # [not win]
-        - freexl  # [not win]
+        - freexl
         - openjpeg
         - curl
         - expat
-        - sqlite  # [not win]
-        - libspatialite  # [not win]
+        - sqlite 3.13.*
+        - libspatialite
 
     run:
         - python
@@ -63,7 +61,6 @@ requirements:
         - xerces-c
         - libnetcdf 4.4.*
         - kealib
-        - krb5
         - libtiff 4.0.*
         - libpng >=1.6.21,<1.7
         - zlib 1.2.*  # [not win]
@@ -71,12 +68,12 @@ requirements:
         - postgresql  # [not win]
         - giflib  # [not win]
         - json-c  # [not win]
-        - freexl  # [not win]
+        - freexl
         - openjpeg
         - curl
         - expat
-        - sqlite  # [not win]
-        - libspatialite  # [not win]
+        - sqlite 3.13.*
+        - libspatialite
 
 test:
     files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,10 @@ source:
         - disable_jpeg12.patch  # [win]
         - windowshdf5.patch  # [win]
         - install_scripts.patch
+        - config_site.patch  # [not win]
 
 build:
-    number: 6
+    number: 7
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -28,7 +29,6 @@ requirements:
     build:
         - python
         - setuptools
-        - toolchain
         - cmake  # [win]
         - numpy x.x
         - hdf4

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -51,6 +51,18 @@ assert driver is not None
 driver = gdal.GetDriverByName("WCS")
 assert driver is not None
 
+# only available when freexl successfully linked in
+driver = ogr.GetDriverByName("XLS")
+assert driver is not None
+
+# only available when expat successfully linked in
+driver = ogr.GetDriverByName("KML")
+assert driver is not None
+
+# only available when SQLite successfully linked in
+driver = ogr.GetDriverByName("SQLite")
+assert driver is not None
+
 def has_geos():
     pnt1 = ogr.CreateGeometryFromWkt( 'POINT(10 20)' )
     pnt2 = ogr.CreateGeometryFromWkt( 'POINT(30 20)' )


### PR DESCRIPTION
Do not merge.

This is a demonstration of using the site defaults feature of `configure` to get the right flags to the compiler without breaking `libtool`.

Xref: https://github.com/conda-forge/conda-forge.github.io/issues/183, https://github.com/conda-forge/gdal-feedstock/pull/85.

Background: `toolchain` sets CC, CFLAGS etc environment variables to control the flags passed to the compiler. This seems to break `libtool`. One option is to pass the variables on the command line like https://github.com/conda-forge/gdal-feedstock/pull/85 but this is error prone. Another possibility is to have our own `libtool`, but this seems likely to be a lot of work.

`autoconf` has a “Site Defaults” feature (https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Site-Defaults.html) and this PR demonstrates having a file with the flags and setting the `$CONFIG_SITE` environment variable to it. Ideally, this would be done by `toolchain`. None of the CC, CFLAGS environment variables need to be set.

One drawback of this approach is that `cmake` and other build systems won't have access to the environment variables – maybe they will need to `source $CONFIG_SITE` or something similar.

Apologies if this isn't clear. And sorry, some of my other changes seem to have ended up here too...

cc @kmuehlbauer @ocefpaf @jakirkham 