### PR TITLE
Store existing GDAL environment variables on activate and restore on …

### DIFF
--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -1,4 +1,18 @@
-if not defined GDAL_DATA (
-  set "GDAL_DATA=%~dp0\..\..\..\Library\share\gdal"
-  set _CONDA_SET_GDAL_DATA=1
+@REM Store existing GDAL env vars and set to this conda env
+@REM so other GDAL installs don't pollute the environment
+
+@if defined GDAL_DATA (
+    set "_CONDA_SET_GDAL_DATA=%GDAL_DATA%"
+)
+@set "GDAL_DATA=%CONDA_PREFIX%\Library\share\gdal"
+
+@if defined GDAL_DRIVER_PATH (
+    set "_CONDA_SET_GDAL_DRIVER_PATH=%GDAL_DRIVER_PATH%"
+)
+
+@REM Support plugins if the plugin directory exists
+@REM i.e if it has been manually created by the user
+@set "GDAL_DRIVER_PATH=%CONDA_PREFIX%\Library\lib\gdalplugins"
+@if not exist %GDAL_DRIVER_PATH% (
+     set "GDAL_DRIVER_PATH="
 )

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
-if [[ -z "$GDAL_DATA" ]]; then
-  export GDAL_DATA=$(gdal-config --datadir)
-  export _CONDA_SET_GDAL_DATA=1
+
+# Store existing GDAL env vars and set to this conda env
+# so other GDAL installs don't pollute the environment
+
+if [[ -n "$GDAL_DATA" ]]; then
+    export _CONDA_SET_GDAL_DATA=$GDAL_DATA
 fi
+export GDAL_DATA=$CONDA_PREFIX/share/gdal
+
+if [[ -n "$GDAL_DRIVER_PATH" ]]; then
+    export _CONDA_SET_GDAL_DRIVER_PATH=$GDAL_DRIVER_PATH
+fi
+export GDAL_DRIVER_PATH=$CONDA_PREFIX/lib/gdal
+
+# Support plugins if the plugin directory exists
+# i.e if it has been manually created by the user
+if [[ ! -d "$GDAL_DRIVER_PATH" ]]; then
+    unset GDAL_DRIVER_PATH
+fi
+

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -11,7 +11,7 @@ export GDAL_DATA=$CONDA_PREFIX/share/gdal
 if [[ -n "$GDAL_DRIVER_PATH" ]]; then
     export _CONDA_SET_GDAL_DRIVER_PATH=$GDAL_DRIVER_PATH
 fi
-export GDAL_DRIVER_PATH=$CONDA_PREFIX/lib/gdal
+export GDAL_DRIVER_PATH=$CONDA_PREFIX/lib/gdalplugins
 
 # Support plugins if the plugin directory exists
 # i.e if it has been manually created by the user

--- a/recipe/scripts/deactivate.bat
+++ b/recipe/scripts/deactivate.bat
@@ -1,4 +1,13 @@
+REM Restore previous GDAL env vars if they were set
+
+set "GDAL_DATA="
 if defined _CONDA_SET_GDAL_DATA (
-  set "GDAL_DATA="
+  set "GDAL_DATA=%_CONDA_SET_GDAL_DATA%"
   set "_CONDA_SET_GDAL_DATA="
+)
+
+set "GDAL_DRIVER_PATH="
+if defined _CONDA_SET_GDAL_DRIVER_PATH (
+  set "GDAL_DRIVER_PATH=%_CONDA_SET_GDAL_DRIVER_PATH%"
+  set "_CONDA_SET_GDAL_DRIVER_PATH="
 )

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
+# Restore previous GDAL env vars if they were set
+
+unset GDAL_DATA
 if [[ -n "$_CONDA_SET_GDAL_DATA" ]]; then
-  unset GDAL_DATA
-  unset _CONDA_SET_GDAL_DATA
+    export GDAL_DATA=$_CONDA_SET_GDAL_DATA
+    unset _CONDA_SET_GDAL_DATA
 fi
+
+unset GDAL_DRIVER_PATH
+if [[ -n "$_CONDA_SET_GDAL_DRIVER_PATH" ]]; then
+    export GDAL_DRIVER_PATH=$_CONDA_SET_GDAL_DRIVER_PATH
+    unset _CONDA_SET_GDAL_DRIVER_PATH
+fi
+


### PR DESCRIPTION
This PR is to fix an issue I was having with a non-conda installed version of GDAL conflicting with the conda-forge GDAL.

Store existing GDAL environment variables on activate and restore on deactivate so other GDAL installs don't pollute the environment.

Support GDAL plugins if the gdalplugins directory exists, i.e if it has been manually created by the user.
