### PR TITLE
Regenerate python bindings

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -88,9 +88,11 @@ copy *.lib %LIBRARY_LIB%\ || exit 1
 if errorlevel 1 exit 1
 
 :: Python bindings
-cd swig\python
-%PYTHON% setup.py build
+cd swig
+nmake /f makefile.vc python %BLD_OPTS%
 if errorlevel 1 exit 1
+
+cd python
 
 %PYTHON% setup.py install
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -78,6 +78,12 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
             --with-dods-root=$PREFIX \
             $OPTS
 
+# Regenerate python bindings.
+cd swig/python
+make veryclean
+make generate
+cd ../..
+
 # CircleCI offers two cores.
 make -j 2 >> $BUILD_OUTPUT 2>&1
 make install >> $BUILD_OUTPUT 2>&1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -85,7 +85,7 @@ make generate
 cd ../..
 
 # CircleCI offers two cores.
-make -j 2 >> $BUILD_OUTPUT 2>&1
+make -j $CPU_COUNT >> $BUILD_OUTPUT 2>&1
 make install >> $BUILD_OUTPUT 2>&1
 
 # Make sure GDAL_DATA and set and still present in the package.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   build:
     - python
     - swig
+    - sed # [osx]
     - setuptools
     - cmake  # [win]
     - numpy x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   build:
     - python
     - swig
-    - sed # [osx]
+    - sed  # [osx]
     - setuptools
     - cmake  # [win]
     - numpy x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - install_scripts.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ build:
 requirements:
   build:
     - python
+    - swig
     - setuptools
     - cmake  # [win]
     - numpy x.x
@@ -75,6 +76,7 @@ requirements:
     - expat
     - sqlite 3.13.*
     - libspatialite
+    - pcre
     - vc   9  # [win and py27]
     - vc  10  # [win and py34]
     - vc  14  # [win and py35]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -98,5 +98,19 @@ def has_proj():
 
 assert has_proj(), 'PROJ not available within GDAL'
 
+# Test https://github.com/swig/swig/issues/567
+def make_geom():
+    geom = ogr.Geometry(ogr.wkbPoint)
+    geom.AddPoint_2D(0, 0)
+    return geom
+
+def gen_list(N):
+    for i in range(N):
+        geom = make_geom()
+        yield i
+
+N = 10
+assert list(gen_list(N)) == list(range(N))
+
 # This module does some additional tests.
 import extra_tests


### PR DESCRIPTION
I seem to have encountered the issue described in https://github.com/swig/swig/issues/567.

in python 3.5
``` python
from osgeo import ogr

def make_geom():
    geom = ogr.Geometry(ogr.wkbPoint)
    geom.AddPoint_2D(0, 0)
    return geom

def gen_list(N):
    for i in range(N):
        geom = make_geom()
        yield i

N = 10
print('gen', list(gen_list(N)))
```
produces `SystemError: <built-in function delete_Geometry> returned a result with an error set`

The issue have been resolved in swig 3.0.8 but the bindings that come with GDAL sources are generated with SWIG 2.0.12.

Regenerating the bindings with the latest swig resolves the issue, but also adds libpcre as a run-time dependency.