### PR TITLE
Support Windows Bash users

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -111,3 +111,9 @@ if errorlevel 1 exit 1
 
 copy %RECIPE_DIR%\scripts\deactivate.bat %DEACTIVATE_DIR%\gdal-deactivate.bat
 if errorlevel 1 exit 1
+
+copy %RECIPE_DIR%\scripts\activate.sh %ACTIVATE_DIR%\gdal-activate.sh
+if errorlevel 1 exit 1
+
+copy %RECIPE_DIR%\scripts\deactivate.sh %DEACTIVATE_DIR%\gdal-deactivate.sh
+if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -112,6 +112,7 @@ if errorlevel 1 exit 1
 copy %RECIPE_DIR%\scripts\deactivate.bat %DEACTIVATE_DIR%\gdal-deactivate.bat
 if errorlevel 1 exit 1
 
+:: Copy unix shell activation scripts, needed by Windows Bash users
 copy %RECIPE_DIR%\scripts\activate.sh %ACTIVATE_DIR%\gdal-activate.sh
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - install_scripts.patch
 
 build:
-  number: 5
+  number: 6
   # Just a temporary skip to ensure CircleCI completion with the most common Python versions.
   skip: True  # [py34 and linux]
   features:


### PR DESCRIPTION
I use conda in Windows with the Bash shell,  so need environment variable activation 
shell scripts as well as batch scripts. I'm sure I'm not the only one.