### PR TITLE
hide batch command output

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,22 +57,22 @@ environment:
     - TARGET_ARCH: x86
       CONDA_NPY: 111
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
     - TARGET_ARCH: x86
       CONDA_NPY: 112
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_NPY: 112
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -83,7 +83,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - install_scripts.patch
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]

--- a/recipe/scripts/deactivate.bat
+++ b/recipe/scripts/deactivate.bat
@@ -1,13 +1,13 @@
-REM Restore previous GDAL env vars if they were set
+@REM Restore previous GDAL env vars if they were set
 
-set "GDAL_DATA="
-if defined _CONDA_SET_GDAL_DATA (
+@set "GDAL_DATA="
+@if defined _CONDA_SET_GDAL_DATA (
   set "GDAL_DATA=%_CONDA_SET_GDAL_DATA%"
   set "_CONDA_SET_GDAL_DATA="
 )
 
-set "GDAL_DRIVER_PATH="
-if defined _CONDA_SET_GDAL_DRIVER_PATH (
+@set "GDAL_DRIVER_PATH="
+@if defined _CONDA_SET_GDAL_DRIVER_PATH (
   set "GDAL_DRIVER_PATH=%_CONDA_SET_GDAL_DRIVER_PATH%"
   set "_CONDA_SET_GDAL_DRIVER_PATH="
 )


### PR DESCRIPTION
Currently, on deactivating an environment, this script outputs each step its executing. Hide these executions.