### PR TITLE
Update gdal-activate.sh to work in Windows + Linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - install_scripts.patch
 
 build:
-  number: 2
+  number: 3
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -6,12 +6,21 @@
 if [[ -n "$GDAL_DATA" ]]; then
     export _CONDA_SET_GDAL_DATA=$GDAL_DATA
 fi
-export GDAL_DATA=$CONDA_PREFIX/share/gdal
 
 if [[ -n "$GDAL_DRIVER_PATH" ]]; then
     export _CONDA_SET_GDAL_DRIVER_PATH=$GDAL_DRIVER_PATH
 fi
-export GDAL_DRIVER_PATH=$CONDA_PREFIX/lib/gdalplugins
+
+# On Linux GDAL_DATA is in $CONDA_PREFIX/share/gdal, but
+# Windows keeps it in $CONDA_PREFIX/Library/share/gdal
+if [ -d $CONDA_PREFIX/share/gdal ]; then
+    export GDAL_DATA=$CONDA_PREFIX/share/gdal
+    export GDAL_DRIVER_PATH=$CONDA_PREFIX/lib/gdalplugins
+elif [ -d $CONDA_PREFIX/Library/share/gdal ]; then
+    export GDAL_DATA=$CONDA_PREFIX/Library/share/gdal
+    export GDAL_DRIVER_PATH=$CONDA_PREFIX/Library/lib/gdalplugins
+fi
+
 
 # Support plugins if the plugin directory exists
 # i.e if it has been manually created by the user


### PR DESCRIPTION
Unfortunately Windows installs of GDAL place the data files in a different directory to Linux installed.

This patch checks before setting environment variables to see if the target directory exists.
It should fix GDAL environment variables for Windows bash users.