### PR TITLE
Build all but Linux+PY36

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,7 +57,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 6 case(s).
+# Embarking on 4 case(s).
     set -x
     export CONDA_NPY=111
     export CONDA_PY=27
@@ -82,20 +82,6 @@ source run_conda_forge_build_setup
     set -x
     export CONDA_NPY=112
     export CONDA_PY=35
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
-    export CONDA_PY=36
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=112
-    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,7 @@ source:
   fn: gdal-{{ version }}.tar.gz
   url: http://download.osgeo.org/gdal/{{ version }}/gdal-{{ version }}.tar.gz
   sha256: d06546a6e34b77566512a2559e9117402320dd9487de9aa95cb8a377815dc360
+  # Workaround to allow CircleCI to complete.
   patches:
     - clang.patch  # [osx]
     - prepend-dll.patch  # [win]
@@ -20,6 +21,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py36 and linux]
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]


### PR DESCRIPTION
Python 3.6 Linux builds are in https://github.com/conda-forge/gdal-feedstock/tree/gdal2_PY36_linux now.