### PR TITLE
Force a rebuild as new kealib version has broken gdal

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - install_scripts.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py36 and linux]
   features:
     - vc9  # [win and py27]


### PR DESCRIPTION
Get `error while loading shared libraries: libkea.so.1.4.6: cannot open shared object file: No such file or directory` when upgrade to latest `libkea` build. New library name is `libkea.so.1.4.7`. Not sure why `gdal` is linked to an exact version rather than just `1.4`....