### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - install_scripts.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py36 and linux]
   features:
     - vc9  # [win and py27]
@@ -34,7 +34,7 @@ requirements:
     - cmake  # [win]
     - numpy x.x
     - hdf4
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - geos 3.5.*
     - proj4 4.9.3
     - xerces-c
@@ -62,7 +62,7 @@ requirements:
     - python
     - numpy x.x
     - hdf4
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - geos 3.5.*
     - proj4 4.9.3
     - xerces-c


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71