### PR TITLE
Add a dependency to the icu package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ requirements:
     - expat
     - sqlite 3.13.*
     - libspatialite
+    - icu
     - vc   9  # [win and py27]
     - vc  10  # [win and py34]
     - vc  14  # [win and py>=35]
@@ -82,6 +83,7 @@ requirements:
     - expat
     - sqlite 3.13.*
     - libspatialite
+    - icu
     - vc   9  # [win and py27]
     - vc  10  # [win and py34]
     - vc  14  # [win and py>=35]


### PR DESCRIPTION
The libgdal.so requires the icu package. See issue #158. This commit
adds a build and run dependency on the icu package.