### PR TITLE
rebuild without cfitsio

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,8 @@ requirements:
     - openjpeg
     - openssl
     - pcre
-    - poppler
+    - poppler  0.67.0  # [win]
+    - poppler  # [not win]
     - postgresql
     - proj4 5.2.0
     - sqlite
@@ -101,7 +102,8 @@ outputs:
         - openjpeg
         - openssl
         - pcre
-        - poppler
+        - poppler  0.67.0  # [win]
+        - poppler  # [not win]
         - postgresql
         - proj4 5.2.0
         - sqlite
@@ -118,7 +120,8 @@ outputs:
         - libpq
         - libspatialite
         - libuuid  # [linux]
-        - poppler
+        - poppler  0.67.0  # [win]
+        - poppler  # [not win]
         - postgresql
         - proj4 5.2.0
         - xz  # [not win or vc>=14]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/setcsvfilenamehook.patch  # [win]
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
Should with the packages that still rely on the old `proj4 <6`, like `cartopy` and `rasterio`, but got hit by the `cfitsio` ABI breakage.