### PR TITLE
Bump build number

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -30,8 +30,6 @@ hdf4:
 - '4.2'
 hdf5:
 - 1.10.5
-icu:
-- '64.2'
 jpeg:
 - '9'
 json_c:
@@ -69,8 +67,6 @@ pin_run_as_build:
     max_pin: x.x.x
   hdf4:
     max_pin: x.x
-  icu:
-    max_pin: x
   jpeg:
     max_pin: x
   json-c:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -30,8 +30,6 @@ hdf4:
 - '4.2'
 hdf5:
 - 1.10.5
-icu:
-- '64.2'
 jpeg:
 - '9'
 json_c:
@@ -71,8 +69,6 @@ pin_run_as_build:
     max_pin: x.x.x
   hdf4:
     max_pin: x.x
-  icu:
-    max_pin: x
   jpeg:
     max_pin: x
   json-c:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015vc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015vc14.yaml
@@ -24,8 +24,6 @@ hdf4:
 - '4.2'
 hdf5:
 - 1.10.5
-icu:
-- '64.2'
 jpeg:
 - '9'
 kealib:
@@ -57,8 +55,6 @@ pin_run_as_build:
     max_pin: x.x.x
   hdf4:
     max_pin: x.x
-  icu:
-    max_pin: x
   jpeg:
     max_pin: x
   kealib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/disable_jpeg12.patch  # [win]
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win and vc<14]
 
 requirements:
@@ -35,7 +35,7 @@ requirements:
     - giflib  # [not win]
     - hdf4
     - hdf5
-    - icu
+    - icu 58.2
     - jpeg
     - json-c  # [not win]
     - kealib
@@ -85,7 +85,7 @@ outputs:
         - giflib  # [not win]
         - hdf4
         - hdf5
-        - icu
+        - icu 58.2
         - jpeg
         - json-c  # [not win]
         - kealib
@@ -113,7 +113,7 @@ outputs:
         - cfitsio
         - geotiff
         - giflib  # [not win]
-        - icu
+        - icu 58.2
         - json-c  # [not win]
         - libdap4  # [not win]
         - libpq


### PR DESCRIPTION
I made a mistake with build number `3`. This should fix it for the old `icu` version.