### PR TITLE
CFEP-18: Remove static libraries from main build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -60,6 +60,7 @@ bash configure --prefix=${PREFIX} \
                --with-xml2=yes \
                --with-zstd=${PREFIX} \
                --without-python \
+               --disable-static \
                --verbose \
                ${OPTS}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - disable_jpeg12.patch  # [win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -132,17 +132,6 @@ outputs:
         - test_data
         - run_test.bat
         - run_test.sh
-      commands:
-        - gdal_grid --version
-        - gdal_rasterize --version
-        - gdal_translate --version
-        - gdaladdo --version
-        - gdalenhance --version
-        - gdalwarp --version
-        - gdalinfo --formats
-        - gdalinfo http://thredds.nersc.no/thredds/dodsC/greenpath/Model/topaz  # [not win]
-        - run_test.bat  # [win]
-        - bash run_test.sh  # [not win]
     about:
       summary: The Geospatial Data Abstraction Library (GDAL)
 

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -17,3 +17,10 @@ if errorlevel 1 exit 1
 :: Check shapefile read.
 ogrinfo sites.shp
 if errorlevel 1 exit 1
+        - gdal_grid --version
+        - gdal_rasterize --version
+        - gdal_translate --version
+        - gdaladdo --version
+        - gdalenhance --version
+        - gdalwarp --version
+        - gdalinfo --formats

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -17,10 +17,17 @@ if errorlevel 1 exit 1
 :: Check shapefile read.
 ogrinfo sites.shp
 if errorlevel 1 exit 1
-        - gdal_grid --version
-        - gdal_rasterize --version
-        - gdal_translate --version
-        - gdaladdo --version
-        - gdalenhance --version
-        - gdalwarp --version
-        - gdalinfo --formats
+gdal_grid --version
+if errorlevel 1 exit 1
+gdal_rasterize --version
+if errorlevel 1 exit 1
+gdal_translate --version
+if errorlevel 1 exit 1
+gdaladdo --version
+if errorlevel 1 exit 1
+gdalenhance --version
+if errorlevel 1 exit 1
+gdalwarp --version
+if errorlevel 1 exit 1
+gdalinfo --formats
+if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -40,3 +40,14 @@ echo ""
 ogrinfo sample.kmz
 
 popd
+
+gdal_grid --version
+gdal_rasterize --version
+gdal_translate --version
+gdaladdo --version
+gdalenhance --version
+gdalwarp --version
+gdalinfo --formats
+gdalinfo http://thredds.nersc.no/thredds/dodsC/greenpath/Model/topaz
+test -f ${PREFIX}/lib/libgdal${SHLIB_EXT}
+test ! -f ${PREFIX}/lib/libgdal.a


### PR DESCRIPTION
This removes the static libraries from the main package according to [CFEP-18](https://github.com/conda-forge/cfep/pull/34). This might break some downstream builds but this is intended and we should fix the downstream builds to use the shared libraries before adding an output here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
