### PR TITLE
Drop v3.1.x and v3.2.x from abi_migration_branches

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -90,8 +90,6 @@ pin_run_as_build:
     max_pin: x.x
   openjpeg:
     max_pin: x.x
-  openssl:
-    max_pin: x.x.x
   poppler:
     max_pin: x.x
   python:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -94,8 +94,6 @@ pin_run_as_build:
     max_pin: x.x
   openjpeg:
     max_pin: x.x
-  openssl:
-    max_pin: x.x.x
   poppler:
     max_pin: x.x
   python:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -90,8 +90,6 @@ pin_run_as_build:
     max_pin: x.x
   openjpeg:
     max_pin: x.x
-  openssl:
-    max_pin: x.x.x
   poppler:
     max_pin: x.x
   python:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -86,8 +86,6 @@ pin_run_as_build:
     max_pin: x.x
   openjpeg:
     max_pin: x.x
-  openssl:
-    max_pin: x.x.x
   poppler:
     max_pin: x.x
   python:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -84,8 +84,6 @@ pin_run_as_build:
     max_pin: x.x
   openjpeg:
     max_pin: x.x
-  openssl:
-    max_pin: x.x.x
   poppler:
     max_pin: x.x
   python:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -70,8 +70,6 @@ pin_run_as_build:
     max_pin: x.x
   openjpeg:
     max_pin: x.x
-  openssl:
-    max_pin: x.x.x
   poppler:
     max_pin: x.x
   python:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-bot:
-  abi_migration_branches: [v3.2.x]
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux: azure, linux_aarch64: azure, linux_ppc64le: azure, osx: azure, win: azure}

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,5 @@
 bot:
-  abi_migration_branches: [v3.1.x, v3.2.x]
+  abi_migration_branches: [v3.2.x]
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux: azure, linux_aarch64: azure, linux_ppc64le: azure, osx: azure, win: azure}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #532
closes #528
closes #526
closes #487
closes #491