### PR TITLE
[ci skip] [skip ci] [cf admin skip] ***NO_CI*** drop 3.3 migration branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,3 @@
-bot:
-  abi_migration_branches:
-  - v3.3.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
Given the build failure with newer `poppler` in #599, perhaps it is time to let go of the `3.3.x` bot migration branch.