### PR TITLE
Rebuild for geotiff 1.7.0

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -23,7 +23,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -23,7 +23,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -27,7 +27,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -27,7 +27,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -23,7 +23,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -23,7 +23,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -21,7 +21,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -21,7 +21,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -21,7 +21,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -21,7 +21,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 giflib:
 - '5.2'
 hdf4:

--- a/.ci_support/win_64_openssl1.1.1.yaml
+++ b/.ci_support/win_64_openssl1.1.1.yaml
@@ -15,7 +15,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 hdf4:
 - 4.2.15
 hdf5:

--- a/.ci_support/win_64_openssl3.yaml
+++ b/.ci_support/win_64_openssl3.yaml
@@ -15,7 +15,7 @@ expat:
 geos:
 - 3.10.2
 geotiff:
-- '1.7'
+- 1.7.0
 hdf4:
 - 4.2.15
 hdf5:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - disable_jpeg12.patch  # [win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR brings GDAL back in line with conda-forge-pinning, which just corrected the geotiff pin to 1.7.0.  The issue is that some repos were getting 1.7.1 due to the loose pinning and then creating dependency islands.