### PR TITLE
run_test.sh: remove DODS testing

### DIFF
--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -49,9 +49,5 @@ gdalenhance --version
 gdalwarp --version
 gdalinfo --formats
 
-# allow the DODS test to run for now
-export GDAL_ENABLE_DEPRECATED_DRIVER_DODS=YES
-gdalinfo http://thredds.nersc.no/thredds/dodsC/greenpath/Model/topaz
-
 test -f ${PREFIX}/lib/libgdal${SHLIB_EXT}
 test ! -f ${PREFIX}/lib/libgdal.a


### PR DESCRIPTION
I'm unclear why the recipe tests this particular driver... Anyway I'm
about to either remove that driver upstream (cf
https://github.com/OSGeo/gdal/issues/5173), or perhaps less radical
option, just require to have a DODS_RASTER: prefix at the beginning of the
connection string. In any case, if not changing this recipee, this would
break the GDAL upstream CI task that uses this recipee to build a Conda package from master.

(I don't think this justify bumping the version number?)