### PR TITLE
Windows build: disable only MSSQL ODBC, not ODBC (fixes #650)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -26,7 +26,7 @@ cmake -G "Ninja" ^
       -DKEA_INCLUDE_DIR:PATH="%LIBRARY_INC%" ^
       -DKEA_LIBRARY:PATH="%LIBRARY_LIB%\libkea.lib" ^
       -DGDAL_USE_MYSQL:BOOL=OFF ^
-      -DGDAL_USE_ODBC:BOOL=OFF ^
+      -DGDAL_USE_MSSQL_ODBC:BOOL=OFF ^
       "%SRC_DIR%"
 
 if errorlevel 1 exit /b 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-Improve-numpy-fixing.patch
 
 build:
-  number: 0
+  number: 1
   skip_compile_pyc:
     - "share/bash-completion/completions/*.py"
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
