### PR TITLE
Remove unused libdap4 dependency, and update pcre->pcre2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-Improve-numpy-fixing.patch
 
 build:
-  number: 2
+  number: 3
   skip_compile_pyc:
     - "share/bash-completion/completions/*.py"
 
@@ -39,7 +39,6 @@ requirements:
     - jpeg
     - json-c  # [not win]
     - kealib
-    - libdap4  # [not win]
     - libkml
     - libnetcdf
     - libpng
@@ -51,7 +50,7 @@ requirements:
     - libxml2
     - openjpeg
     - openssl
-    - pcre
+    - pcre2
     - poppler
     - postgresql
     - proj
@@ -97,7 +96,6 @@ outputs:
         - jpeg
         - json-c  # [not win]
         - kealib
-        - libdap4  # [not win]
         - libkml
         - libnetcdf
         - libpng
@@ -109,7 +107,7 @@ outputs:
         - libxml2
         - openjpeg
         - openssl
-        - pcre
+        - pcre2
         - poppler
         - postgresql
         - proj
@@ -124,7 +122,6 @@ outputs:
         - geotiff
         - giflib  # [not win]
         - json-c  # [not win]
-        - libdap4  # [not win]
         - libpq
         - libspatialite
         - libuuid  # [linux]


### PR DESCRIPTION
libdap4 was necessary for the DODS drivers, but they have been removed in GDAL 3.5.0, so just drop this dependency.

pcre is deprecated. GDAL supports pcre2 too, so use the later

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
