### PR TITLE
activate.bat and activate.ps1: fix GDAL_DRIVER_PATH

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-Improve-numpy-fixing.patch
 
 build:
-  number: 5
+  number: 6
   skip_compile_pyc:
     - "share/bash-completion/completions/*.py"
 

--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -12,7 +12,7 @@
 
 @REM Support plugins if the plugin directory exists
 @REM i.e if it has been manually created by the user
-@set "GDAL_DRIVER_PATH=%CONDA_PREFIX%\Library\bin\gdalplugins"
+@set "GDAL_DRIVER_PATH=%CONDA_PREFIX%\Library\lib\gdalplugins"
 @if not exist "%GDAL_DRIVER_PATH%" (
      set "GDAL_DRIVER_PATH="
 )

--- a/recipe/scripts/activate.ps1
+++ b/recipe/scripts/activate.ps1
@@ -8,7 +8,7 @@ if ($ENV:GDAL_DRIVER_PATH) {
     $ENV:_CONDA_SET_GDAL_DRIVER_PATH=$ENV:GDAL_DRIVER_PATH
 }
 
-$ENV:GDAL_DRIVER_PATH="$ENV:CONDA_PREFIX\Library\bin\gdalplugins"
+$ENV:GDAL_DRIVER_PATH="$ENV:CONDA_PREFIX\Library\lib\gdalplugins"
 if (-Not (Test-Path $ENV:GDAL_DRIVER_PATH) ) {
      Remove-Item ENV:GDAL_DRIVER_PATH
 }


### PR DESCRIPTION
I realized that the failure in the testing of the Arrow/Parquet plugins on Windows in https://github.com/conda-forge/gdal-feedstock/pull/679 was due to a wrong GDAL_DRIVER_PATH in activate.bat and activate.ps1
This PR fixes that independently