### PR TITLE
Add libdeflate dependency

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -38,6 +38,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -38,6 +38,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -42,6 +42,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -42,6 +42,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -38,6 +38,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -38,6 +38,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -36,6 +36,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -36,6 +36,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -36,6 +36,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -36,6 +36,8 @@ json_c:
 - '0.16'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:

--- a/.ci_support/win_64_openssl1.1.1.yaml
+++ b/.ci_support/win_64_openssl1.1.1.yaml
@@ -26,6 +26,8 @@ jpeg:
 - '9'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:
@@ -70,8 +72,6 @@ target_platform:
 - win-64
 tiledb:
 - '2.11'
-vc:
-- '14'
 xerces_c:
 - '3.2'
 xz:

--- a/.ci_support/win_64_openssl3.yaml
+++ b/.ci_support/win_64_openssl3.yaml
@@ -26,6 +26,8 @@ jpeg:
 - '9'
 kealib:
 - '1.4'
+libdeflate:
+- '1.14'
 libkml:
 - '1.3'
 libnetcdf:
@@ -70,8 +72,6 @@ target_platform:
 - win-64
 tiledb:
 - '2.11'
-vc:
-- '14'
 xerces_c:
 - '3.2'
 xz:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-Improve-numpy-fixing.patch
 
 build:
-  number: 7
+  number: 8
   skip_compile_pyc:
     - "share/bash-completion/completions/*.py"
 
@@ -39,6 +39,7 @@ requirements:
     - jpeg
     - json-c  # [not win]
     - kealib
+    - libdeflate
     - libkml
     - libnetcdf
     - libpng
@@ -97,6 +98,7 @@ outputs:
         - jpeg
         - json-c  # [not win]
         - kealib
+        - libdeflate
         - libkml
         - libnetcdf
         - libpng


### PR DESCRIPTION
It is a faster alternative for zlib in a number of situations, which can accelerate zlib compression/decompression by about a factor of 2.

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
