### PR TITLE
meta.yaml: use bundled qhull instead of packaged one 

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -60,7 +60,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libuuid:
 - '2'
 libwebp_base:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -60,7 +60,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libuuid:
 - '2'
 libwebp_base:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -64,7 +64,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libuuid:
 - '2'
 libwebp_base:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -64,7 +64,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libuuid:
 - '2'
 libwebp_base:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -60,7 +60,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libuuid:
 - '2'
 libwebp_base:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -60,7 +60,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libuuid:
 - '2'
 libwebp_base:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -58,7 +58,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -58,7 +58,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -58,7 +58,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -58,7 +58,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/win_64_openssl1.1.1.yaml
+++ b/.ci_support/win_64_openssl1.1.1.yaml
@@ -48,7 +48,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/win_64_openssl3.yaml
+++ b/.ci_support/win_64_openssl3.yaml
@@ -48,7 +48,7 @@ libpng:
 libpq:
 - '15'
 libtiff:
-- '4'
+- '4.4'
 libwebp_base:
 - '1'
 libxml2:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 68f1c03547ff7152289789db7f67ee634167c9b7bfec4872b88406b236f9c230
 
 build:
-  number: 0
+  number: 1
   skip_compile_pyc:
     - "share/bash-completion/completions/*.py"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,8 @@ requirements:
     - poppler
     - postgresql
     - proj
-    - qhull
+    # qhull disabled because of https://github.com/conda-forge/qgis-feedstock/issues/284#issuecomment-1356490896
+    # - qhull
     - sqlite
     - swig
     - tiledb
@@ -118,7 +119,8 @@ outputs:
         - poppler
         - postgresql
         - proj
-        - qhull
+        # qhull disabled because of https://github.com/conda-forge/qgis-feedstock/issues/284#issuecomment-1356490896
+        # - qhull
         - sqlite
         - tiledb
         - xerces-c


### PR DESCRIPTION
This reverts commit https://github.com/conda-forge/gdal-feedstock/commit/b3bd22d6d45e788b1206a868a88d820c0f6224d5 because of an issue when using gdal and scipy.spatial.Delaunay, the later apparently bundling qhull.
See https://github.com/conda-forge/qgis-feedstock/issues/284#issuecomment-1356490896 for details

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
