### PR TITLE
install_python.sh/bat: use python_generated_files target

### DIFF
--- a/recipe/install_python.bat
+++ b/recipe/install_python.bat
@@ -12,13 +12,10 @@ cmake -DPython_EXECUTABLE="%PYTHON%" ^
       "%SRC_DIR%"
 if errorlevel 1 exit /b 1
 
+cmake --build . --target python_generated_files
+if errorlevel 1 exit /b 1
+
 cd swig\python
-if errorlevel 1 exit /b 1
-
-copy "%SRC_DIR%"\swig\python\osgeo\*.py osgeo
-if errorlevel 1 exit /b 1
-
-copy "%SRC_DIR%"\swig\python\extensions\*.c* extensions
 if errorlevel 1 exit /b 1
 
 %PYTHON% setup.py install

--- a/recipe/install_python.sh
+++ b/recipe/install_python.sh
@@ -15,9 +15,8 @@ cmake -DPython_EXECUTABLE="$PYTHON" \
       -DOGR_BUILD_OPTIONAL_DRIVERS:BOOL=OFF \
       ${SRC_DIR} || (cat CMakeFiles/CMakeError.log;false)
 
+cmake --build . --target python_generated_files
 cd swig/python
-cp ${SRC_DIR}/swig/python/osgeo/*.py osgeo/
-cp ${SRC_DIR}/swig/python/extensions/*.c* extensions/
 
 cat >pyproject.toml <<EOF
 [build-system]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 35f40d2e08061b342513cdcddc2b997b3814ef8254514f0ef1e8bc7aa56cf681
 
 build:
-  number: 8
+  number: 9
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
 


### PR DESCRIPTION
This is cleaner than manual copying of the pre-generated files, especially since in GDAL master/3.7.0dev, those files have been removed from git, and thus GDAL CI Conda-based master builds are currently broken
