### PR TITLE
Rebuild with icu72

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -16,7 +16,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -36,7 +36,7 @@ hdf4:
 hdf5:
 - 1.14.0
 icu:
-- '70'
+- '72'
 json_c:
 - '0.16'
 kealib:
@@ -44,7 +44,7 @@ kealib:
 lerc:
 - '4'
 libcurl:
-- '7'
+- '8'
 libdeflate:
 - '1.18'
 libiconv:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -20,7 +20,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -40,7 +40,7 @@ hdf4:
 hdf5:
 - 1.14.0
 icu:
-- '70'
+- '72'
 json_c:
 - '0.16'
 kealib:
@@ -48,7 +48,7 @@ kealib:
 lerc:
 - '4'
 libcurl:
-- '7'
+- '8'
 libdeflate:
 - '1.18'
 libiconv:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -16,7 +16,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -36,7 +36,7 @@ hdf4:
 hdf5:
 - 1.14.0
 icu:
-- '70'
+- '72'
 json_c:
 - '0.16'
 kealib:
@@ -44,7 +44,7 @@ kealib:
 lerc:
 - '4'
 libcurl:
-- '7'
+- '8'
 libdeflate:
 - '1.18'
 libiconv:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -16,7 +16,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
@@ -34,7 +34,7 @@ hdf4:
 hdf5:
 - 1.14.0
 icu:
-- '70'
+- '72'
 json_c:
 - '0.16'
 kealib:
@@ -42,7 +42,7 @@ kealib:
 lerc:
 - '4'
 libcurl:
-- '7'
+- '8'
 libdeflate:
 - '1.18'
 libiconv:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -16,7 +16,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
@@ -34,7 +34,7 @@ hdf4:
 hdf5:
 - 1.14.0
 icu:
-- '70'
+- '72'
 json_c:
 - '0.16'
 kealib:
@@ -42,7 +42,7 @@ kealib:
 lerc:
 - '4'
 libcurl:
-- '7'
+- '8'
 libdeflate:
 - '1.18'
 libiconv:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -12,7 +12,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - vs2019
 expat:
@@ -26,13 +26,13 @@ hdf4:
 hdf5:
 - 1.14.0
 icu:
-- '70'
+- '72'
 kealib:
 - '1.5'
 lerc:
 - '4'
 libcurl:
-- '7'
+- '8'
 libdeflate:
 - '1.18'
 libiconv:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 3cccbed883b1fb99b913966aa3a650ad930e7c3afc714f5823f9754176ee49ea
 
 build:
-  number: 7
+  number: 8
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
 


### PR DESCRIPTION
With the icu72 upgrade being propagated (e.g. to uwsgi) it would be great to have gdal rebuilt so that it is compatible, enabling Django users with geospatial library support to run both uwsgi and gdal :-) 

I was unable to figure out how to register this feedstock for the more automatic version bumps, but this change was straightforward to do by hand to match https://github.com/conda-forge/uwsgi-feedstock/pull/62 CC @ocefpaf 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
