### PR TITLE
Remove `build: skip` to enable later `libarrow` versions

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,8 +1,3 @@
-arrow_cpp:
-- 10.0.1
-- 11.0.0
-- '12'
-- '13'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -43,6 +38,11 @@ lerc:
 - '4'
 libarchive:
 - '3.7'
+libarrow:
+- 10.0.1
+- 11.0.0
+- '12'
+- '13'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,10 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-arrow_cpp:
-- 10.0.1
-- 11.0.0
-- '12'
-- '13'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -47,6 +42,11 @@ lerc:
 - '4'
 libarchive:
 - '3.7'
+libarrow:
+- 10.0.1
+- 11.0.0
+- '12'
+- '13'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,8 +1,3 @@
-arrow_cpp:
-- 10.0.1
-- 11.0.0
-- '12'
-- '13'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -43,6 +38,11 @@ lerc:
 - '4'
 libarchive:
 - '3.7'
+libarrow:
+- 10.0.1
+- 11.0.0
+- '12'
+- '13'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,10 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
-arrow_cpp:
-- 10.0.1
-- 11.0.0
-- '12'
-- '13'
 c_compiler:
 - clang
 c_compiler_version:
@@ -41,6 +36,11 @@ lerc:
 - '4'
 libarchive:
 - '3.7'
+libarrow:
+- 10.0.1
+- 11.0.0
+- '12'
+- '13'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,10 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-arrow_cpp:
-- 10.0.1
-- 11.0.0
-- '12'
-- '13'
 c_compiler:
 - clang
 c_compiler_version:
@@ -41,6 +36,11 @@ lerc:
 - '4'
 libarchive:
 - '3.7'
+libarrow:
+- 10.0.1
+- 11.0.0
+- '12'
+- '13'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,8 +1,3 @@
-arrow_cpp:
-- 10.0.1
-- 11.0.0
-- '12'
-- '13'
 c_compiler:
 - vs2019
 cfitsio:
@@ -31,6 +26,11 @@ lerc:
 - '4'
 libarchive:
 - '3.7'
+libarrow:
+- 10.0.1
+- 11.0.0
+- '12'
+- '13'
 libcurl:
 - '8'
 libdeflate:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -181,7 +181,6 @@ outputs:
         - libjpeg-turbo
         - json-c  # [not win]
         - kealib
-        - arrow-cpp
         - libarchive
         - libarrow
         - libkml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -183,6 +183,7 @@ outputs:
         - kealib
         - arrow-cpp
         - libarchive
+        - libarrow
         - libkml
         - libnetcdf
         - libpng

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -155,9 +155,6 @@ outputs:
   - name: libgdal-arrow-parquet
     script: build_arrow_parquet.sh  # [unix]
     script: build_arrow_parquet.bat  # [win]
-    build:
-      # only for libarrow > 10
-      skip: true  # [arrow_cpp != "10.0.1"]
     requirements:
       build:
         - cmake


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

As described in https://github.com/conda-forge/gdal-feedstock/issues/797, `libgdal-arrow-parquet` currently only supports `arrow_cpp == "10.0.1"`. This `build: skip` section looks suspicious, and seems to indicate that this package should only be built for this specific arrow cpp version.