### PR TITLE
[v3.7.x backport]Add upstream patch for compatibility with libxml2 2.12

### DIFF
--- a/recipe/0002-Fix-build-error-with-libxml2-2.12.patch
+++ b/recipe/0002-Fix-build-error-with-libxml2-2.12.patch
@@ -1,0 +1,25 @@
+From fbc09135a3e59131742fbaf29b97988f5bc276df Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 18 Nov 2023 15:38:46 +0100
+Subject: [PATCH] Fix build error with libxml2 2.12
+
+---
+ port/cpl_xml_validate.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/port/cpl_xml_validate.cpp b/port/cpl_xml_validate.cpp
+index 7eb49ff40c..29070d957b 100644
+--- a/port/cpl_xml_validate.cpp
++++ b/port/cpl_xml_validate.cpp
+@@ -914,7 +914,7 @@ static void CPLLibXMLWarningErrorCallback(void *ctx, const char *msg, ...)
+ 
+     if (strstr(pszStr, "since this namespace was already imported") == nullptr)
+     {
+-        xmlErrorPtr pErrorPtr = xmlGetLastError();
++        const xmlError *pErrorPtr = xmlGetLastError();
+         const char *pszFilename = static_cast<char *>(ctx);
+         char *pszStrDup = CPLStrdup(pszStr);
+         int nLen = static_cast<int>(strlen(pszStrDup));
+-- 
+2.25.1
+

--- a/recipe/0003-Fix-build-error-with-libxml2-2.12-cont-d.patch
+++ b/recipe/0003-Fix-build-error-with-libxml2-2.12-cont-d.patch
@@ -1,0 +1,30 @@
+From 71ef2427edb7d351178bcc9008cb7f3cdb1a16cb Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 18 Nov 2023 16:33:25 +0100
+Subject: [PATCH] Fix build error with libxml2 2.12 (cont'd)
+
+---
+ gcore/gdaljp2metadatagenerator.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/gcore/gdaljp2metadatagenerator.cpp b/gcore/gdaljp2metadatagenerator.cpp
+index b6caa2db9d..751fa3d5e9 100644
+--- a/gcore/gdaljp2metadatagenerator.cpp
++++ b/gcore/gdaljp2metadatagenerator.cpp
+@@ -357,7 +357,12 @@ static CPLString GDALGMLJP2EvalExpr(const CPLString &osTemplate,
+ /************************************************************************/
+ 
+ static void GDALGMLJP2XPathErrorHandler(void * /* userData */,
+-                                        xmlErrorPtr error)
++#if LIBXML_VERSION >= 21200
++                                        const xmlError *error
++#else
++                                        xmlErrorPtr error
++#endif
++)
+ {
+     if (error->domain == XML_FROM_XPATH && error->str1 != nullptr &&
+         error->int1 < static_cast<int>(strlen(error->str1)))
+-- 
+2.25.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,11 @@ source:
   sha256: e0a6f0c453ea7eb7c09967f50ac49426808fcd8f259dbc9888140eb69d7ffee6
   patches:
     - 0001-cpl_zipOpenNewFileInZip3-validate-length-of-filename.patch
+    - 0002-Fix-build-error-with-libxml2-2.12.patch
+    - 0003-Fix-build-error-with-libxml2-2.12-cont-d.patch
 
 build:
-  number: 5
+  number: 6
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
