### PR TITLE
Switch to openssl 3.0 in host

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -80,7 +80,7 @@ numpy:
 openjpeg:
 - '2'
 openssl:
-- '3'
+- '3.0'
 pcre2:
 - '10.42'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -84,7 +84,7 @@ numpy:
 openjpeg:
 - '2'
 openssl:
-- '3'
+- '3.0'
 pcre2:
 - '10.42'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -80,7 +80,7 @@ numpy:
 openjpeg:
 - '2'
 openssl:
-- '3'
+- '3.0'
 pcre2:
 - '10.42'
 pin_run_as_build:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -78,7 +78,7 @@ numpy:
 openjpeg:
 - '2'
 openssl:
-- '3'
+- '3.0'
 pcre2:
 - '10.42'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -78,7 +78,7 @@ numpy:
 openjpeg:
 - '2'
 openssl:
-- '3'
+- '3.0'
 pcre2:
 - '10.42'
 pin_run_as_build:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -66,7 +66,7 @@ numpy:
 openjpeg:
 - '2'
 openssl:
-- '3'
+- '3.0'
 pcre2:
 - '10.42'
 pin_run_as_build:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# build against 3.0 for now, because some users cannot use 3.2;
+# openssl's run-export is major-version only, meaning builds
+# against 3.0 can be used with 3.2.
+openssl:
+  - 3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/002_libarrow15_compat.patch
 
 build:
-  number: 1
+  number: 2
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
 
@@ -273,9 +273,6 @@ outputs:
         # See: https://github.com/conda-forge/gdal-feedstock/pull/415
         - hdf5
         - libxml2
-        # Workaround to prevent conflicts seen in
-        #  https://github.com/conda-forge/gdal-feedstock/pull/543
-        - openssl
       run:
         - python
         - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
Drop openssl from gdal (but not libgdal)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
closes #886 
