### PR TITLE
Test entry points, call all Python apps with --help

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 577f80e9d14ff7c90b6bfbc34201652b4546700c01543efb4f4c3050e0b3fda2
 
 build:
-  number: 4
+  number: 5
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   skip: true  # [ppc64le]
@@ -294,35 +294,47 @@ outputs:
         - osgeo._osr
       commands:
         - python run_test.py
-        # Check Python-implemented GDAL utilities.
-        # A number of these utilities unexpectedly return an error value when
-        # called with --help, and are thus called with --version below.
-        # gdalattachpct.py is checked only for existence as it unexpectedly
-        # returns an error code on --version, too. For easier debugging, this
-        # existence check is performed in a separate .bat file on Windows.
-        # This existence check should be replaced by a regular call once
-        # behavior is fixed in GDAL itself.
-        - rgb2pct.py --help
-        - pct2rgb.py --help
-        # Both --help and --version seem to cause an error return value
-        - test -f $PREFIX/bin/gdalattachpct.py  # [unix]
-        - gdal_merge.py --help
+        # Check that Python-implemented GDAL utilities are available with .py extension, as documented
         - gdal2tiles.py --help
         - gdal2xyz.py --help
-        - gdal_retile.py --help
-        - gdal_proximity.py --help
-        - gdal_polygonize.py --help
-        - gdal_sieve.py --version
-        - gdal_fillnodata.py --help
-        - gdalmove.py --version
-        - gdal_edit.py --help
         - gdal_calc.py --help
+        - gdal_edit.py --help
+        - gdal_fillnodata.py --help
+        - gdal_merge.py --help
         - gdal_pansharpen.py --help
-        - gdalcompare.py --version
+        - gdal_polygonize.py --help
+        - gdal_proximity.py --help
+        - gdal_retile.py --help
+        - gdal_sieve.py --help
+        - gdalattachpct.py --help
+        - gdalcompare.py --help
+        - gdalmove.py --help
+        - pct2rgb.py --help
+        - rgb2pct.py --help
         - ogrmerge.py --help
         - ogr_layer_algebra.py --help
-        # Use separate .bat file for file existence check on Windows
-        - test_script_exist.bat  # [win]
+        # Check that the utilities are available as entry points without extension, see:
+        # https://github.com/conda-forge/gdal-feedstock/issues/834
+        # https://github.com/OSGeo/gdal/pull/8718
+        # https://github.com/OSGeo/gdal/issues/8811
+        - gdal2tiles --help
+        - gdal2xyz --help
+        - gdal_calc --help
+        - gdal_edit --help
+        - gdal_fillnodata --help
+        - gdal_merge --help
+        - gdal_pansharpen --help
+        - gdal_polygonize --help
+        - gdal_proximity --help
+        - gdal_retile --help
+        - gdal_sieve --help
+        - gdalattachpct --help
+        - gdalcompare --help
+        - gdalmove --help
+        - pct2rgb --help
+        - rgb2pct --help
+        - ogrmerge --help
+        - ogr_layer_algebra --help
       about:
         summary: Python wrapper for the Geospatial Data Abstraction Library (GDAL)
         license: MIT

--- a/recipe/test_script_exist.bat
+++ b/recipe/test_script_exist.bat
@@ -1,9 +1,0 @@
-@echo off
-REM As a workaround for GDAL apps unexpectedly returning error codes, this
-REM script checks only for the existence of the .py files below.
-REM This file should be replaced by calls to the scripts in meta.yaml once the
-REM behavior is fixed in GDAL itself.
-
-@echo on
-
-if not exist %PREFIX%\Scripts\gdalattachpct.py exit 1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes #834 

<!--
Please add any other relevant info below:
-->

Now that GDAL 3.9 has landed, we can test the proper entry points (Python apps, called without the .py extension). Also incorporated are changes (as a result of upstream GDAL fixes) so that all of these apps are now tested with `--help`, see https://github.com/OSGeo/gdal/issues/8717.

There has been a bit of churn on GDAL upstream regarding these entry points, see:
- https://github.com/OSGeo/gdal/pull/8718
- https://github.com/OSGeo/gdal/pull/8774
- https://github.com/OSGeo/gdal/issues/8811
- https://github.com/OSGeo/gdal/pull/8815
- https://github.com/OSGeo/gdal/pull/8824

The commands including `.py` are still the ones shown in GDAL docs, so for now I test both e.g. `gdal_calc.py` and `gdal_calc`.