### PR TITLE
Remove tests for programs with .py extension

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 577f80e9d14ff7c90b6bfbc34201652b4546700c01543efb4f4c3050e0b3fda2
 
 build:
-  number: 5
+  number: 6
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   skip: true  # [ppc64le]
@@ -294,29 +294,7 @@ outputs:
         - osgeo._osr
       commands:
         - python run_test.py
-        # Check that Python-implemented GDAL utilities are available with .py extension, as documented
-        - gdal2tiles.py --help
-        - gdal2xyz.py --help
-        - gdal_calc.py --help
-        - gdal_edit.py --help
-        - gdal_fillnodata.py --help
-        - gdal_merge.py --help
-        - gdal_pansharpen.py --help
-        - gdal_polygonize.py --help
-        - gdal_proximity.py --help
-        - gdal_retile.py --help
-        - gdal_sieve.py --help
-        - gdalattachpct.py --help
-        - gdalcompare.py --help
-        - gdalmove.py --help
-        - pct2rgb.py --help
-        - rgb2pct.py --help
-        - ogrmerge.py --help
-        - ogr_layer_algebra.py --help
-        # Check that the utilities are available as entry points without extension, see:
-        # https://github.com/conda-forge/gdal-feedstock/issues/834
-        # https://github.com/OSGeo/gdal/pull/8718
-        # https://github.com/OSGeo/gdal/issues/8811
+        # Check availability of Python programs
         - gdal2tiles --help
         - gdal2xyz --help
         - gdal_calc --help


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Just noticed that the `.py` extension has recently been removed from the [GDAL docs](https://gdal.org/programs/index.html) of Python programs. As a followup to #934, ditch the tests of calls with `.py`.

There are currently 3 programs for which the docs still have `.py`, I've opened [this PR](https://github.com/OSGeo/gdal/pull/10053) to fix that.