### PR TITLE
install_python.sh: manually set Python_NumPy_INCLUDE_DIR

### DIFF
--- a/recipe/install_python.sh
+++ b/recipe/install_python.sh
@@ -10,8 +10,11 @@ rm -rf swig/python
 
 Python_LOOKUP_VERSION=$($PYTHON -c "import sys; print(str(sys.version_info.major)+'.'+str(sys.version_info.minor)+'.'+str(sys.version_info.micro))")
 
+Python_NumPy_INCLUDE_DIR=$($PYTHON -c "import numpy; print(numpy.get_include())")
+
 cmake "-UPython*" "-U*LATER_PLUGIN" \
       -DPython_LOOKUP_VERSION=${Python_LOOKUP_VERSION} \
+      -DPython_NumPy_INCLUDE_DIR=${Python_NumPy_INCLUDE_DIR} \
       -DBUILD_PYTHON_BINDINGS:BOOL=ON \
       ${SRC_DIR} || (cat CMakeFiles/CMakeError.log;false)
 


### PR DESCRIPTION
This patch (which is an upstreaming of a OSGeo/GDAL one: https://github.com/OSGeo/gdal/commit/c9c4e09c457a9407873ff4d947a131ea4d1bc9b5) doesn't seem necessary for builds using conda-forge infrastructure, but I found it necessary for GDAL master builds running on GDAL GitHub action CI, where for some reason, for some Python configuration (namely python 3.12.5 + numpy 2.0), the FindPython CMake package doesn't manage to locate numpy (but it works for other python versions using numpy 2.0)...
I'd note that the install_python.bat already uses a similar trick, so at least that's not a totally new thing.

I didn't bump the build number, as this should not require updating exiting packages.
