### PR TITLE
[ci skip] [skip ci] [cf admin skip] ***NO_CI*** drop v3.8.x migration branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,3 @@
-bot:
-  abi_migration_branches:
-  - v3.8.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
The `v3.8.x` branch has become un-buildable with current conda-forge pinning, so any rerender will lead to a busted build.

see #982 for tiledb
see #980 for python 3.13
see #974 for poppler 24.08

We can always add back a v3.9.x migration branch, when that time comes :)