### PR TITLE
Python bindings: fix compatibility issue with SWIG 4.3.0 and PYTHONWARNINGS=error

### DIFF
--- a/recipe/0001-Python-bindings-fix-compatibility-issue-with-SWIG-43.patch
+++ b/recipe/0001-Python-bindings-fix-compatibility-issue-with-SWIG-43.patch
@@ -1,0 +1,13 @@
+diff --git a/swig/python/modify_cpp_files.cmake b/swig/python/modify_cpp_files.cmake
+index af6668b018..fe4b8489c1 100644
+--- a/swig/python/modify_cpp_files.cmake
++++ b/swig/python/modify_cpp_files.cmake
+@@ -60,4 +60,8 @@ string(REPLACE "if (--interpreter_counter != 0) // another sub-interpreter may s
+                "/* Even Rouault / GDAL hack for SWIG >= 4.1 related to objects not being freed. See swig/python/modify_cpp_files.cmake for more details */\nif( 1 )"
+        _CONTENTS "${_CONTENTS}")
+ 
++# Works around https://github.com/swig/swig/issues/3061
++string(REPLACE "# define SWIG_HEAPTYPES" "// Below is disabled because of https://github.com/swig/swig/issues/3061\n// # define SWIG_HEAPTYPES"
++       _CONTENTS "${_CONTENTS}")
++
+ file(WRITE ${FILE} "${_CONTENTS}")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -655,6 +655,7 @@ outputs:
         - osgeo._osr
       commands:
         - python test_python.py
+        - PYTHONWARNINGS="error" python -c "import osgeo; print(osgeo.__version__)"  # [not win]
         # Check that Python-implemented GDAL utilities are available with .py extension, as documented
         - gdal2tiles.py --help
         - gdal2xyz.py --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha256: 34a037852ffe6d2163f1b8948a1aa7019ff767148aea55876c1339b22ad751f1
   patches:
     - 000_cmake.patch  # [osx]
+    - 0001-Python-bindings-fix-compatibility-issue-with-SWIG-43.patch
 
 build:
-  number: 0
+  number: 1
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/gdal-feedstock/issues/995
    
Upstream fix in https://github.com/OSGeo/gdal/pull/11154

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
