### PR TITLE
Rebuild for libarrow 18.0 + patch needed for 3.9.3

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -43,10 +43,10 @@ libaec:
 libarchive:
 - '3.7'
 libarrow:
-- '14'
 - '15'
 - '16.1'
 - '17.0'
+- '18.0'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -47,10 +47,10 @@ libaec:
 libarchive:
 - '3.7'
 libarrow:
-- '14'
 - '15'
 - '16.1'
 - '17.0'
+- '18.0'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -43,10 +43,10 @@ libaec:
 libarchive:
 - '3.7'
 libarrow:
-- '14'
 - '15'
 - '16.1'
 - '17.0'
+- '18.0'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/migrations/libarrow180.yaml
+++ b/.ci_support/migrations/libarrow180.yaml
@@ -1,0 +1,21 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libarrow 18.0
+  kind: version
+  migration_number: 1
+  exclude:
+    - pyarrow
+    - r-arrow
+    - arrow-c-glib
+
+libarrow:
+- '18.0'
+- '17.0'
+- '16.1'
+- 15
+libarrow_all:
+- '18.0'
+- '17.0'
+- '16.1'
+- 15
+migrator_ts: 1730165218.7348938

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -43,10 +43,10 @@ libaec:
 libarchive:
 - '3.7'
 libarrow:
-- '14'
 - '15'
 - '16.1'
 - '17.0'
+- '18.0'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -43,10 +43,10 @@ libaec:
 libarchive:
 - '3.7'
 libarrow:
-- '14'
 - '15'
 - '16.1'
 - '17.0'
+- '18.0'
 libcurl:
 - '8'
 libdeflate:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -29,10 +29,10 @@ libaec:
 libarchive:
 - '3.7'
 libarrow:
-- '14'
 - '15'
 - '16.1'
 - '17.0'
+- '18.0'
 libcurl:
 - '8'
 libdeflate:

--- a/recipe/0002-libarrow-18-min-compat.patch
+++ b/recipe/0002-libarrow-18-min-compat.patch
@@ -1,0 +1,23 @@
+diff --git a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+index fc8013301e..e613c0f1d9 100644
+--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
++++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+@@ -1427,6 +1427,10 @@ bool OGRParquetLayer::ReadNextBatch()
+ {
+     m_nIdxInBatch = 0;
+ 
++    const int nNumGroups = m_poArrowReader->num_row_groups();
++    if (nNumGroups == 0)
++        return false;
++
+     if (m_bSingleBatch)
+     {
+         CPLAssert(m_iRecordBatch == 0);
+@@ -1468,7 +1472,6 @@ bool OGRParquetLayer::ReadNextBatch()
+         }
+         else
+         {
+-            const int nNumGroups = m_poArrowReader->num_row_groups();
+             OGRField sMin;
+             OGRField sMax;
+             OGR_RawField_SetNull(&sMin);

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Python-bindings-fix-compatibility-issue-with-SWIG-43.patch
 
 build:
-  number: 1
+  number: 2
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   patches:
     - 000_cmake.patch  # [osx]
     - 0001-Python-bindings-fix-compatibility-issue-with-SWIG-43.patch
+    - 0002-libarrow-18-min-compat.patch
 
 build:
   number: 2


### PR DESCRIPTION
Continuation of https://github.com/conda-forge/gdal-feedstock/pull/997 including a patch needed for GDAL 3.9.3 to be compatible of Parquet files with 0 row groups.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
