### PR TITLE
meta.yml: pin libgdal-xxxx plugins to same x.y.z version of libgdal-core

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 000_cmake.patch  # [osx]
 
 build:
-  number: 4
+  number: 5
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:
@@ -112,7 +112,7 @@ outputs:
         - libarrow-dataset  # [libarrow != 13]
         - libparquet        # [libarrow != 13]
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/ogr_Arrow${SHLIB_EXT}        # [unix]
@@ -154,7 +154,7 @@ outputs:
         - openjpeg
         - expat
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]
@@ -194,7 +194,7 @@ outputs:
         - expat
         - poppler
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       files:
         - test_data
@@ -241,7 +241,7 @@ outputs:
         - libpq
         - postgresql
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
         - postgresql
     test:
       commands:
@@ -283,7 +283,7 @@ outputs:
         - libpq
         - postgresql
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
         - postgresql
     test:
       commands:
@@ -322,7 +322,7 @@ outputs:
         - expat
         - freexl
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]
@@ -362,7 +362,7 @@ outputs:
         - expat
         - cfitsio
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]
@@ -402,7 +402,7 @@ outputs:
         - expat
         - libaec
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]
@@ -444,7 +444,7 @@ outputs:
         - kealib
         - hdf5
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
         - libgdal-hdf5 {{ version }}.*
     test:
       commands:
@@ -485,7 +485,7 @@ outputs:
         - expat
         - tiledb
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]
@@ -529,7 +529,7 @@ outputs:
         - expat
         - libnetcdf
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
         - libgdal-hdf5 {{ version }}.*
         - libgdal-hdf4 {{ version }}.*
     test:
@@ -571,7 +571,7 @@ outputs:
         - expat
         - hdf5
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]
@@ -612,7 +612,7 @@ outputs:
         - hdf4
         - libaec
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]
@@ -774,7 +774,7 @@ outputs:
         - libavif
         - expat
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]
@@ -814,7 +814,7 @@ outputs:
         - libheif
         - expat
       run:
-        - libgdal-core >={{ ".".join(version.split(".")[:2]) }}
+        - {{ pin_subpackage('libgdal-core', exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/gdalplugins/${GDAL_PLUGIN_TYPE}_${GDAL_PLUGIN_NAME}${SHLIB_EXT}      # [unix]


### PR DESCRIPTION
Fixes #1016

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
