### PR TITLE
Bring compatibility for SWIG 4.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha256: 335a8d2c7567d783563d3fed37e8b58d72d9c1723f6fd1d8c299fe4c0d936781
   patches:
     - 000_cmake.patch  # [osx]
+    - swig-4.3.1-compat.patch
 
 build:
-  number: 2
+  number: 3
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:

--- a/recipe/swig-4.3.1-compat.patch
+++ b/recipe/swig-4.3.1-compat.patch
@@ -1,0 +1,16 @@
+diff --git a/swig/python/modify_cpp_files.cmake b/swig/python/modify_cpp_files.cmake
+index 3d1e459593..8408cc25d6 100644
+--- a/swig/python/modify_cpp_files.cmake
++++ b/swig/python/modify_cpp_files.cmake
+@@ -62,7 +62,11 @@ string(REPLACE "if (--interpreter_counter != 0) // another sub-interpreter may s
+        _CONTENTS "${_CONTENTS}")
+ 
+ # Works around https://github.com/swig/swig/issues/3061
++# For SWIG 4.3.0:
+ string(REPLACE "# define SWIG_HEAPTYPES" "// Below is disabled because of https://github.com/swig/swig/issues/3061\n// # define SWIG_HEAPTYPES"
+        _CONTENTS "${_CONTENTS}")
++# For SWIG 4.3.1:
++string(REPLACE "#define SWIG_HEAPTYPES" "// Below is disabled because of https://github.com/swig/swig/issues/3061\n// # define SWIG_HEAPTYPES"
++       _CONTENTS "${_CONTENTS}")
+ 
+ file(WRITE ${FILE} "${_CONTENTS}")


### PR DESCRIPTION
Fixes issue  https://github.com/conda-forge/gdal-feedstock/issues/995 that was fixed for SWIG 4.3.0 but needs a slight adjustment for 4.3.1

Corresponds to GDAL upstream fix:
https://github.com/OSGeo/gdal/commit/19671ee60c3e58242b7a2754744f1b73d3fe6ef7

This patch will have to be dropped for GDAL 3.11

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
