### PR TITLE
Add JPEGXL-in-TIFF support and JPEGXL driver

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -24,8 +24,6 @@ expat:
 - '2'
 geos:
 - 3.13.1
-geotiff:
-- '1.7'
 giflib:
 - '5.2'
 hdf4:
@@ -71,8 +69,6 @@ libpng:
 - '1.6'
 libpq:
 - '17'
-libtiff:
-- '4.7'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -24,8 +24,6 @@ expat:
 - '2'
 geos:
 - 3.13.1
-geotiff:
-- '1.7'
 giflib:
 - '5.2'
 hdf4:
@@ -71,8 +69,6 @@ libpng:
 - '1.6'
 libpq:
 - '17'
-libtiff:
-- '4.7'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -24,8 +24,6 @@ expat:
 - '2'
 geos:
 - 3.13.1
-geotiff:
-- '1.7'
 giflib:
 - '5.2'
 hdf4:
@@ -71,8 +69,6 @@ libpng:
 - '1.6'
 libpq:
 - '17'
-libtiff:
-- '4.7'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -24,8 +24,6 @@ expat:
 - '2'
 geos:
 - 3.13.1
-geotiff:
-- '1.7'
 giflib:
 - '5.2'
 hdf4:
@@ -71,8 +69,6 @@ libpng:
 - '1.6'
 libpq:
 - '17'
-libtiff:
-- '4.7'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -24,8 +24,6 @@ expat:
 - '2'
 geos:
 - 3.13.1
-geotiff:
-- '1.7'
 giflib:
 - '5.2'
 hdf4:
@@ -71,8 +69,6 @@ libpng:
 - '1.6'
 libpq:
 - '17'
-libtiff:
-- '4.7'
 libwebp_base:
 - '1'
 libxml2:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -14,8 +14,6 @@ expat:
 - '2'
 geos:
 - 3.13.1
-geotiff:
-- '1.7'
 hdf4:
 - 4.2.15
 hdf5:
@@ -57,8 +55,6 @@ libpng:
 - '1.6'
 libpq:
 - '17'
-libtiff:
-- '4.7'
 libwebp_base:
 - '1'
 libxml2:

--- a/recipe/LICENSE_libgeotiff.txt
+++ b/recipe/LICENSE_libgeotiff.txt
@@ -1,0 +1,80 @@
+	libgeotiff Licensing
+	====================
+
+All the source code in this toolkit are either in the public domain, or under 
+the MIT License.  In any event it is all considered to be free to use
+for any purpose (including commercial software).  No credit is required 
+though some of the code requires that the specific source code modules 
+retain their existing copyright statements.  In 
+particular, no part of this code is "copyleft", nor does it imply any 
+requirement for users to disclose this or their own source code.
+
+All components not carrying their own copyright message, but distributed
+with libgeotiff should be considered to be under the same license as
+Niles' code.
+
+---------
+
+Code by Frank Warmerdam has this copyright notice (directly copied from
+X Consortium licence):
+
+ * Copyright (c) 1999, Frank Warmerdam
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+
+-----------
+
+Code by Niles Ritter is under this licence:
+
+ *    Written By: Niles D. Ritter.
+ *
+ *  copyright (c) 1995   Niles D. Ritter
+ *
+ *  Permission granted to use this software, so long as this copyright
+ *  notice accompanies any products derived therefrom.
+
+----------
+
+The cmake/*.cmake macros are under the following BSD license.  This does 
+not affect produced binaries or the library.
+
+--
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products 
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/LICENSE_libtiff.txt
+++ b/recipe/LICENSE_libtiff.txt
@@ -1,0 +1,8 @@
+Copyright © 1988-1997 Sam Leffler
+Copyright © 1991-1997 Silicon Graphics, Inc.
+
+Permission to use, copy, modify, distribute, and sell this software and its documentation for any purpose is hereby granted without fee, provided that (i) the above copyright notices and this permission notice appear in all copies of the software and related documentation, and (ii) the names of Sam Leffler and Silicon Graphics may not be used in any advertising or publicity relating to the software without the specific, prior written permission of Sam Leffler and Silicon Graphics.
+
+THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND, EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+IN NO EVENT SHALL SAM LEFFLER OR SILICON GRAPHICS BE LIABLE FOR ANY SPECIAL, INCIDENTAL, INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,6 +12,7 @@ if  %vc% GTR 9 set MSVC_TS_VER=140
 REM Make sure to disable Arrow/Parquet dependencies for now, so they are only
 REM used in build_arrow_parquet
 
+REM We use internal libtiff and libgeotiff for JXL-in-TIFF support
 cmake -G "Ninja" ^
       "%CMAKE_ARGS%" ^
       -DCMAKE_BUILD_TYPE=Release ^
@@ -23,6 +24,8 @@ cmake -G "Ninja" ^
       -DBUILD_PYTHON_BINDINGS:BOOL=OFF ^
       -DBUILD_JAVA_BINDINGS:BOOL=OFF ^
       -DBUILD_CSHARP_BINDINGS:BOOL=OFF ^
+      -DGDAL_USE_TIFF_INTERNAL:BOOL=ON ^
+      -DGDAL_USE_GEOTIFF_INTERNAL:BOOL=ON ^
       -DGDAL_USE_MYSQL:BOOL=OFF ^
       -DGDAL_USE_MSSQL_ODBC:BOOL=OFF ^
       -DGDAL_USE_PARQUET=OFF ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,8 @@ cd build
 
 # Make sure to disable Arrow/Parquet dependencies for now, so they are only
 # used in build_arrow_parquet
+
+# We use internal libtiff and libgeotiff for JXL-in-TIFF support
 cmake -G "Unix Makefiles" \
       ${CMAKE_ARGS} \
       -DCMAKE_BUILD_TYPE=Release \
@@ -20,6 +22,8 @@ cmake -G "Unix Makefiles" \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_TESTING=OFF \
+      -DGDAL_USE_TIFF_INTERNAL:BOOL=ON \
+      -DGDAL_USE_GEOTIFF_INTERNAL:BOOL=ON \
       -DGDAL_USE_PARQUET=OFF \
       -DGDAL_USE_ARROW=OFF \
       -DGDAL_USE_ARROWDATASET=OFF \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 000_cmake.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:
@@ -39,7 +39,8 @@ requirements:
     - blosc
     - expat
     - geos
-    - geotiff
+    # We use internal libtiff and libgeotiff for JXL-in-TIFF support
+    # - geotiff
     - giflib  # [not win]
     - libjpeg-turbo
     - json-c  # [not win]
@@ -48,11 +49,13 @@ requirements:
     - libcurl
     - libdeflate
     - libiconv
+    - libjxl
     - libkml-devel
     - liblzma-devel
     - libpng
     - libspatialite
-    - libtiff
+    # We use internal libtiff and libgeotiff for JXL-in-TIFF support
+    # - libtiff
     - libwebp-base
     - libxml2
     - lz4-c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -762,7 +762,10 @@ outputs:
 about:
   home: http://www.gdal.org
   license: MIT
-  license_file: LICENSE.TXT
+  license_file:
+      - LICENSE.TXT
+      - LICENSE_libtiff.txt
+      - LICENSE_libgeotiff.txt
   summary: |
     GDAL is a translator library for raster and vector geospatial data formats that is released under an
     X/MIT style Open Source license by the Open Source Geospatial Foundation.

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -54,3 +54,5 @@ test ! -f ${PREFIX}/lib/libgdal.a
 
 # check all drivers
 gdal_translate --formats
+
+gdalinfo --format GTiff | grep JXL


### PR DESCRIPTION
For the former we have to use internal libtiff and geotiff. I'm not totally sure if it is OK w.r.t conda-forge packaging policies ? Technicially it is safe, since the symbols of those vendored libraries are prefixed with GDAL_ to avoid any clash if  an application/library linking against GDAL is also linked against libtiff

Fixes #752

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
