### PR TITLE
Use lgpl versions of libarchive and libspatialite

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 000_cmake.patch  # [osx]
 
 build:
-  number: 4
+  number: 5
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:
@@ -45,7 +45,7 @@ requirements:
     - libjpeg-turbo
     - json-c  # [not win]
     - lerc
-    - libarchive
+    - libarchive * lgpl*
     - libcurl
     - libdeflate
     - libiconv
@@ -53,7 +53,7 @@ requirements:
     - libkml-devel
     - liblzma-devel
     - libpng
-    - libspatialite
+    - libspatialite * lgpl*
     # We use internal libtiff and libgeotiff for JXL-in-TIFF support
     # - libtiff
     - libwebp-base


### PR DESCRIPTION
LZO and RTTOPO aren't really used by GDAL, so removing them from the build makes it possible to download and redistribute GDAL without trespassing the GPL license of underlying packages.

Fixes #1118 #1119

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
