### PR TITLE
Avoid testing command-line Python tools on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -613,24 +613,24 @@ outputs:
         - python test_python.py
         - PYTHONWARNINGS="error" python -c "import osgeo; print(osgeo.__version__)"  # [not win]
         # Check that Python-implemented GDAL utilities are available with .py extension, as documented
-        - gdal2tiles.py --help
-        - gdal2xyz.py --help
-        - gdal_calc.py --help
-        - gdal_edit.py --help
-        - gdal_fillnodata.py --help
-        - gdal_merge.py --help
-        - gdal_pansharpen.py --help
-        - gdal_polygonize.py --help
-        - gdal_proximity.py --help
-        - gdal_retile.py --help
-        - gdal_sieve.py --help
-        - gdalattachpct.py --help
-        - gdalcompare.py --help
-        - gdalmove.py --help
-        - pct2rgb.py --help
-        - rgb2pct.py --help
-        - ogrmerge.py --help
-        - ogr_layer_algebra.py --help
+        - gdal2tiles.py --help  # [not win]
+        - gdal2xyz.py --help  # [not win]
+        - gdal_calc.py --help  # [not win]
+        - gdal_edit.py --help  # [not win]
+        - gdal_fillnodata.py --help  # [not win]
+        - gdal_merge.py --help  # [not win]
+        - gdal_pansharpen.py --help  # [not win]
+        - gdal_polygonize.py --help  # [not win]
+        - gdal_proximity.py --help  # [not win]
+        - gdal_retile.py --help  # [not win]
+        - gdal_sieve.py --help  # [not win]
+        - gdalattachpct.py --help  # [not win]
+        - gdalcompare.py --help  # [not win]
+        - gdalmove.py --help  # [not win]
+        - pct2rgb.py --help  # [not win]
+        - rgb2pct.py --help  # [not win]
+        - ogrmerge.py --help  # [not win]
+        - ogr_layer_algebra.py --help  # [not win]
         # Check that the utilities are available as entry points without extension, see:
         # https://github.com/conda-forge/gdal-feedstock/issues/834
         # https://github.com/OSGeo/gdal/pull/8718


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Temporary fix for https://github.com/OSGeo/gdal/issues/13265 by avoiding testing these commands on Windows. If enabled, they make a pop-up dialog appear asking which program should be used to open `.py` files. When running on CI this isn't clear and the build hangs until timing-out. 

This issue was mentioned previously in https://github.com/conda-forge/gdal-feedstock/pull/835#issuecomment-1801641634

I've tested this on a fork of GDAL and the Conda action successfully completes on Windows with this PR. https://github.com/geographika/gdal/actions/runs/18778920230/job/53579936177