### PR TITLE
[ci skip] [skip ci] [cf admin skip] ***NO_CI*** drop v3.10.x branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,7 +5,6 @@ azure:
       MINIFORGE_HOME: C:\Miniforge
 bot:
   abi_migration_branches:
-  - v3.10.x
   - v3.11.x
 build_platform:
   linux_aarch64: linux_64


### PR DESCRIPTION
This is the equivalent of #1068 for v3.10.x.  As we had seen with v3.9.x then, v3.10.x seems to have become a burden with failing poppler migrations.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Closes #1160 
Closes #1161 
Closes #1166 
Closes #1169 