### PR TITLE
bump build to get proj9.7 + gdal 3.12.3 build

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -91,7 +91,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.8'
+- '9.7'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -91,7 +91,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.8'
+- '9.7'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -91,7 +91,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.8'
+- '9.7'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/migrations/proj98.yaml
+++ b/.ci_support/migrations/proj98.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for proj 9.8
-  kind: version
-  migration_number: 1
-migrator_ts: 1772450367.8448427
-proj:
-- '9.8'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -95,7 +95,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.8'
+- '9.7'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -95,7 +95,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.8'
+- '9.7'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -79,7 +79,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.8'
+- '9.7'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 000_cmake.patch  # [osx]
 
 build:
-  number: 2
+  number: 3
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

refs #1191 
@conda-forge-admin please rerender
conda-forge-pinning reverted to proj 9.7, so a rerender should pick this up creating a 3.12.3 build with proj 9.7 support.