### PR TITLE
Re-enable PROJ 9.8 migration

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -91,7 +91,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.7'
+- '9.8'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -91,7 +91,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.7'
+- '9.8'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -91,7 +91,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.7'
+- '9.8'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/migrations/proj98.yaml
+++ b/.ci_support/migrations/proj98.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for proj 9.8
+  kind: version
+  migration_number: 1
+migrator_ts: 1772450367.8448427
+proj:
+- '9.8'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -95,7 +95,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.7'
+- '9.8'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -95,7 +95,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.7'
+- '9.8'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -79,7 +79,7 @@ poppler:
 postgresql:
 - '18'
 proj:
-- '9.7'
+- '9.8'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 000_cmake.patch  # [osx]
 
 build:
-  number: 3
+  number: 4
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:


### PR DESCRIPTION
This reverts https://github.com/conda-forge/gdal-feedstock/pull/1192 (or at least attempts to... )  I was disappointed that my attempt at running conda-smithy rerender on my machine failed because out of memory... And it has 32 GB of RAM... (maybe "only" 20 GB available, but still... )

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
