### PR TITLE
Remove rattler-build workaround and use one build number

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ source:
     - kealib20.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - staging:
@@ -96,7 +96,6 @@ outputs:
       name: libgdal-core
     inherit: core-build
     build:
-      number: 0
       python:
         skip_pyc_compilation:
           - share/bash-completion/completions/*.py
@@ -133,7 +132,6 @@ outputs:
       name: libgdal-arrow-parquet
     inherit: core-build
     build:
-      number: 0
       script:
         file: build_plugin
     requirements:
@@ -173,7 +171,6 @@ outputs:
       name: libgdal-jp2openjpeg
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: JP2OpenJPEG
@@ -217,7 +214,6 @@ outputs:
       name: libgdal-pdf
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: PDF
@@ -268,7 +264,6 @@ outputs:
       name: libgdal-postgisraster
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: PostGISRaster
@@ -314,7 +309,6 @@ outputs:
       name: libgdal-pg
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: PG
@@ -358,7 +352,6 @@ outputs:
       name: libgdal-xls
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: XLS
@@ -402,7 +395,6 @@ outputs:
       name: libgdal-fits
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: FITS
@@ -446,7 +438,6 @@ outputs:
       name: libgdal-grib
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: GRIB
@@ -490,7 +481,6 @@ outputs:
       name: libgdal-kea
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: KEA
@@ -538,7 +528,6 @@ outputs:
       name: libgdal-tiledb
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: TileDB
@@ -582,7 +571,6 @@ outputs:
       name: libgdal-netcdf
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: netCDF
@@ -632,7 +620,6 @@ outputs:
       name: libgdal-hdf5
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: HDF5
@@ -676,7 +663,6 @@ outputs:
       name: libgdal-hdf4
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: HDF4
@@ -721,7 +707,6 @@ outputs:
       name: libgdal-adbc
     inherit: core-build
     build:
-      number: 0
       # FIXME: libadbc-driver-manager is not available currently on Windows
       skip: win
       script:
@@ -767,7 +752,6 @@ outputs:
       name: libgdal-avif
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: AVIF
@@ -811,7 +795,6 @@ outputs:
       name: libgdal-heif
     inherit: core-build
     build:
-      number: 0
       script:
         env:
           GDAL_PLUGIN_NAME: HEIF
@@ -898,7 +881,6 @@ outputs:
       name: gdal
     inherit: core-build
     build:
-      number: 0
       python:
         skip_pyc_compilation:
           - share/bash-completion/completions/*.py


### PR DESCRIPTION
This removes the workaround for the rattler-build bug fixed in the latest release.