### PR TITLE
make highfive a dependency of libgdal-kea at runtime

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -71,7 +71,7 @@ libpq:
 libwebp_base:
 - '1'
 libxml2_devel:
-- '2.14'
+- '2.15'
 lz4_c:
 - '1.10'
 numpy:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -71,7 +71,7 @@ libpq:
 libwebp_base:
 - '1'
 libxml2_devel:
-- '2.14'
+- '2.15'
 lz4_c:
 - '1.10'
 numpy:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -71,7 +71,7 @@ libpq:
 libwebp_base:
 - '1'
 libxml2_devel:
-- '2.14'
+- '2.15'
 lz4_c:
 - '1.10'
 numpy:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -73,7 +73,7 @@ libpq:
 libwebp_base:
 - '1'
 libxml2_devel:
-- '2.14'
+- '2.15'
 lz4_c:
 - '1.10'
 macos_machine:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -73,7 +73,7 @@ libpq:
 libwebp_base:
 - '1'
 libxml2_devel:
-- '2.14'
+- '2.15'
 lz4_c:
 - '1.10'
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -59,7 +59,7 @@ libpq:
 libwebp_base:
 - '1'
 libxml2_devel:
-- '2.14'
+- '2.15'
 lz4_c:
 - '1.10'
 numpy:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ source:
     - kealib20.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - staging:
@@ -505,6 +505,8 @@ outputs:
       run:
         - ${{ pin_subpackage('libgdal-core', exact=True) }}
         - libgdal-hdf5 ${{ version }}.*
+        # make a runtime dependency so people can rebuild this plugin if needed
+        - highfive
     tests:
       - script:
           env:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

xref: https://github.com/OSGeo/gdal/issues/15080

`libkea` requires `highfive` for building against, but not at runtime. However, when people try and rebuild `libgdal` they find they can't because `highfive` is missing which is surprising. This PR adds `highfive` as a run dependency of `libgdal-kea`.